### PR TITLE
Added empty asset_detail to physical_storage inventory collection

### DIFF
--- a/app/models/manageiq/providers/autosde/inventory/parser/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/inventory/parser/storage_manager.rb
@@ -27,10 +27,13 @@ class ManageIQ::Providers::Autosde::Inventory::Parser::StorageManager < ManageIQ
   def physical_storages
     collector.physical_storages.each do |physical_storage_hash|
       system_type_uuid = physical_storage_hash.delete(:system_type_uuid)
-      persister.physical_storages.build(
+      physical_storage = persister.physical_storages.build(
         :physical_storage_family => persister.physical_storage_families.lazy_find(system_type_uuid),
         **physical_storage_hash
       )
+
+      # asset detail is required for physical_storage, even if we don't use it.
+      persister.physical_storage_details.build(:resource => physical_storage)
     end
   end
 

--- a/app/models/manageiq/providers/autosde/inventory/persister/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/inventory/persister/storage_manager.rb
@@ -49,6 +49,9 @@ class ManageIQ::Providers::Autosde::Inventory::Persister::StorageManager < Manag
         :ems_id => ->(persister) { persister.manager.id }
       )
     end
+
+    # asset details
+    add_collection(physical_infra, :physical_storage_details)
   end
 
   def strategy

--- a/spec/models/manageiq/providers/autosde/inventory_spec.rb
+++ b/spec/models/manageiq/providers/autosde/inventory_spec.rb
@@ -13,6 +13,7 @@ describe ManageIQ::Providers::Autosde::Inventory::Parser::StorageManager do
     expect(manager.physical_storages).to_not be_empty
     expect(manager.physical_storage_families).to_not be_empty
     expect(manager.physical_storages.first.physical_storage_family).to eq(manager.physical_storage_families.find_by(:name=>'svc'))
+    expect(manager.physical_storages.first.asset_detail).to be_instance_of(AssetDetail)
 
     expect(manager.storage_resources).to_not be_empty
     expect(manager.storage_resources.first.physical_storage).to eq(manager.physical_storages.first)


### PR DESCRIPTION
We don't use the asset detail in our provider, but various existing function that deal with physical_storage expect it to be there.