### PR TITLE
Fix ems refresh following commit 387abe2

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager.rb
@@ -49,6 +49,10 @@ class ManageIQ::Providers::Autosde::StorageManager < ManageIQ::Providers::Storag
     define_method(:singular_route_key) { "ems_block_storage" }
   end
 
+  def queue_name_for_ems_refresh
+    queue_name
+  end
+
   def self.ems_type
     @ems_type ||= "storage_manager".freeze
   end


### PR DESCRIPTION
In commit https://github.com/ManageIQ/manageiq/commit/387abe2360 array of queue names was delegate to parent_manager. Our manager doesn't have a parent-manager and so we couldn't create our manager.