### PR TITLE
Cancelled debugging output of passwords when creating storage-manager.

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/autosde_client.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/autosde_client.rb
@@ -87,7 +87,7 @@ class ManageIQ::Providers::Autosde::StorageManager::AutosdeClient < OpenapiClien
       config.scheme = @scheme
       config.verify_ssl = false
       config.host = @host
-      config.debugging = true
+      config.debugging = false
       config.verify_ssl_host = false
     end
   end


### PR DESCRIPTION
By default the open-api client logs everything, including credentials.

Also cleaned up some unreachable code.