### PR TITLE
Added empty cloud_tenants and volume_availability_zones to Autosde EMS.

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager.rb
@@ -44,6 +44,17 @@ class ManageIQ::Providers::Autosde::StorageManager < ManageIQ::Providers::Storag
   virtual_column :total_resources, :type => :integer
   virtual_column :resources_info, :type => :json
 
+  attribute :volume_availability_zones, :boolean
+  attribute :cloud_tenants, :boolean
+
+  def cloud_tenants
+    nil
+  end
+
+  def volume_availability_zones
+    nil
+  end
+
   class << model_name
     define_method(:route_key) { "ems_block_storages" }
     define_method(:singular_route_key) { "ems_block_storage" }


### PR DESCRIPTION
Following the changes in https://github.com/ManageIQ/manageiq-ui-classic/commit/7123ca82a356cf60b358fe35e14220a810bcd009

In the mentioned commit, the API call sent by the form was changed. Instead of using `parent_manager.volume_availability_zones` it's now just `volume_availability_zones`. 
This causes an exception if the manager doesn't have volume_availability_zones. Before it would just return `nil` if there was no parent-manager.
Our EMS has no volume_availability_zones, and so we are getting an exception on the new-volume form.

In this PR I try to solve this by providing dummies for the missing fields.