### PR TITLE
Checking for EMS presense before supporting :delete

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
@@ -1,6 +1,8 @@
 class ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage < ::PhysicalStorage
   supports :create
-  supports :delete
+  supports :delete do
+    unsupported_reason_add(:delete, _("The Physical Storage is not connected to an active Manager")) if ext_management_system.nil?
+  end
 
   def raw_delete_physical_storage
     ems = ext_management_system


### PR DESCRIPTION
Following Adam's comment here https://github.com/ManageIQ/manageiq-providers-autosde/pull/38#discussion_r510128610

Before declaring that our PhysicalStorage supports :delete, we now first check that it's got an EMS.