### PR TITLE
Add refresh_interval every 15 minutes

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -20,4 +20,4 @@
         :ems_refresh_worker_autosde: {}
 :ems_refresh:
   :autosde:
-    :inventory_object_refresh: true
+    :refresh_interval: 15.minutes


### PR DESCRIPTION
Without an event catcher we should refresh relatively frequently.  Also
deleted the unused inventory_object_refresh setting since this is always
true now