### PR TITLE
Fix autosde cloud volume editing

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -1,0 +1,3 @@
+AllCops:
+  Exclude:
+  - lib/autosde_oas_client/generated/**/*

--- a/app/models/manageiq/providers/autosde/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager.rb
@@ -5,6 +5,7 @@ class ManageIQ::Providers::Autosde::StorageManager < ManageIQ::Providers::Storag
 
   supports :storage_services
   supports :ems_storage_new
+  supports :volume_resizing
 
   include ManageIQ::Providers::StorageManager::BlockMixin
 

--- a/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
@@ -31,4 +31,22 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
   def validate_delete_volume
     {:available => true, :message => nil}
   end
+
+  # ================= edit  ================
+
+  # override the function in manageiq\app\models\cloud_volume\operations.rb
+  def validate_update_volume
+    {:available => true, :message => nil}
+  end
+
+  def raw_update_volume(options = {})
+    ems = ext_management_system
+    update_details = ems.autosde_client.VolumeUpdate(
+      :name => options[:name],
+      :size => options[:size]
+    )
+
+    ems.autosde_client.VolumeApi.volumes_pk_put(ems_ref, update_details)
+    EmsRefresh.queue_refresh(ems)
+  end
 end

--- a/lib/autosde_oas_client/generated/lib/autosde_openapi_client/models/volume_update.rb
+++ b/lib/autosde_oas_client/generated/lib/autosde_openapi_client/models/volume_update.rb
@@ -15,12 +15,16 @@ require 'date'
 module OpenapiClient
   # TODO add description
   class VolumeUpdate
+    # name
+    attr_accessor :name
+
     # size
     attr_accessor :size
 
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
+        :'name' => :'name',
         :'size' => :'size'
       }
     end
@@ -28,6 +32,7 @@ module OpenapiClient
     # Attribute type mapping.
     def self.openapi_types
       {
+        :'name' => :'String',
         :'size' => :'Integer'
       }
     end
@@ -53,6 +58,12 @@ module OpenapiClient
         h[k.to_sym] = v
       }
 
+      if attributes.key?(:'name')
+        self.name = attributes[:'name']
+      else
+        self.name = 'null'
+      end
+
       if attributes.key?(:'size')
         self.size = attributes[:'size']
       end
@@ -76,6 +87,7 @@ module OpenapiClient
     def ==(o)
       return true if self.equal?(o)
       self.class == o.class &&
+          name == o.name &&
           size == o.size
     end
 
@@ -88,7 +100,7 @@ module OpenapiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [size].hash
+      [name, size].hash
     end
 
     # Builds the object from hash

--- a/lib/autosde_oas_client/site_manager_oas.json
+++ b/lib/autosde_oas_client/site_manager_oas.json
@@ -1874,7 +1874,13 @@
       "volumeUpdate": {
         "description": "TODO add description",
         "properties": {
+          "name": {
+            "default": null,
+            "description": "name",
+            "type": "string"
+          },
           "size": {
+            "default": null,
             "description": "size",
             "type": "integer"
           }


### PR DESCRIPTION
If we try to modify cloud volume managed by autosde storage manager we get an exception. 
This PR enables size and name modifications for volumes managed under autosde.

<img width="644" alt="1" src="https://user-images.githubusercontent.com/53213107/99183903-08945700-2748-11eb-87e4-faef01f27bbe.png">

<img width="642" alt="2" src="https://user-images.githubusercontent.com/53213107/99183902-07632a00-2748-11eb-8918-bee3d83f2dcd.png">

links
-----
https://github.com/ManageIQ/manageiq-ui-classic/pull/7511 - bug fix in the UI preventing autosde cloud volume editing
