### PR TITLE
Removed default for security protocol when creating new EMS

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager.rb
@@ -230,11 +230,12 @@ class ManageIQ::Providers::Autosde::StorageManager < ManageIQ::Providers::Storag
                   :label      => _("Security Protocol"),
                   :isRequired => true,
                   :validate   => [{:type => "required"}],
+                  :includeEmpty => true,
                   :options    => [
                     {
                       :label => _("SSL without validation"),
                       :value => "ssl-no-validation"
-                    },
+                    }
                     # todo[per gregoryb]: need to provide ssl and non-ssl
                     # {
                     #     :label => _("SSL"),


### PR DESCRIPTION
The user now needs to explicitly choose their security protocol when creating a new Autosde EMS.