### PR TITLE
Adjust empty/initial values for select fields in DDF schemas

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager.rb
@@ -224,13 +224,14 @@ class ManageIQ::Providers::Autosde::StorageManager < ManageIQ::Providers::Storag
               :validationDependencies => %w[type endpoints.default.hostname authentications.default.userid authentications.default.password],
               :fields                 => [
                 {
-                  :component  => "select",
-                  :id         => "endpoints.default.security_protocol",
-                  :name       => "endpoints.default.security_protocol",
-                  :label      => _("Security Protocol"),
-                  :isRequired => true,
-                  :validate   => [{:type => "required"}],
-                  :options    => [
+                  :component    => "select",
+                  :id           => "endpoints.default.security_protocol",
+                  :name         => "endpoints.default.security_protocol",
+                  :label        => _("Security Protocol"),
+                  :isRequired   => true,
+                  :validate     => [{:type => "required"}],
+                  :initialValue => 'ssl-no-validation',
+                  :options      => [
                     {
                       :label => _("SSL without validation"),
                       :value => "ssl-no-validation"


### PR DESCRIPTION
Because carbon has four different dropdowns, the DDF schemas need to have explicit initialValue or includeEmpty settings in order to make the form validation work.

@miq-bot assign @agrare