### PR TITLE
Remove unused validate_update_volume

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
@@ -38,11 +38,6 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
 
   # ================= edit  ================
 
-  # override the function in manageiq\app\models\cloud_volume\operations.rb
-  def validate_update_volume
-    {:available => true, :message => nil}
-  end
-
   def raw_update_volume(options = {})
     ems = ext_management_system
     update_details = ems.autosde_client.VolumeUpdate(


### PR DESCRIPTION
Follow-up to: https://github.com/ManageIQ/manageiq/pull/21181

This has been replaced with `supports :update`