### PR TITLE
Add support for editing autosde cloud volume

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager.rb
@@ -7,6 +7,7 @@ class ManageIQ::Providers::Autosde::StorageManager < ManageIQ::Providers::Storag
   supports :ems_storage_new
   supports :volume_resizing
   supports :cloud_volume_create
+  supports :cloud_volume
 
   include ManageIQ::Providers::StorageManager::BlockMixin
 

--- a/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
@@ -57,10 +57,6 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
   end
 
   def params_for_update
-    ems = ExtManagementSystem.find(ems_id)
-    storage_service_id = ems.cloud_volumes.find_by(:id => id)[:storage_service_id]
-    service_value = ems.storage_services.find_by(:id => storage_service_id)[:name]
-
     {
       :fields => [
         {
@@ -70,7 +66,7 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
           :label        => _("Storage Pool"),
           :isRequired   => true,
           :validate     => [{:type => "required"}],
-          :initialValue => service_value,
+          :initialValue => storage_service.name,
           :isDisabled   => true
         },
         {

--- a/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
@@ -8,7 +8,7 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
   def self.raw_create_volume(ext_management_system, options = {})
     # @type [StorageService]
     vol_to_create = ext_management_system.autosde_client.VolumeCreate(
-      :service => ExtManagementSystem.find(options["ems_id"]).storage_services.detect {|e| e.id.to_s ==  options["storage_service_id"]}.ems_ref,
+      :service => ExtManagementSystem.find(options["ems_id"]).storage_services.detect { |e| e.id.to_s == options["storage_service_id"] }.ems_ref,
       :name    => options["name"],
       :size    => options["size"]
     )
@@ -58,10 +58,10 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
 
   def self.params_for_update(provider, params)
     services = provider.storage_services.map { |service| {:value => service.id, :label => service.name} }
-    storage_service_id = ExtManagementSystem.find(params["ems_id"]).cloud_volumes.detect {|e| e.id.to_s ==  params["record_id"]}.storage_service_id
-    service_value = services.detect {|e| e[:value] ==   storage_service_id}[:label]
+    storage_service_id = ExtManagementSystem.find(params["ems_id"]).cloud_volumes.detect { |e| e.id.to_s == params["record_id"] }.storage_service_id
+    service_value = services.detect { |e| e[:value] == storage_service_id }[:label]
 
-    init_volume_size = (ExtManagementSystem.find(params["ems_id"]).cloud_volumes.detect {|e| e.id.to_s ==  params["record_id"]}.size / 1.0.gigabyte).round
+    init_volume_size = (ExtManagementSystem.find(params["ems_id"]).cloud_volumes.detect { |e| e.id.to_s == params["record_id"] }.size / 1.0.gigabyte).round
 
     {
       :fields => [
@@ -76,14 +76,14 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
           :isDisabled   => true
         },
         {
-          :component  => "text-field",
-          :id         => "size_GB",
-          :name       => "size_GB",
-          :label      => _("Size (GiB)"),
-          :isRequired => true,
-          :validate   => [{:type => "required"},
-                          {:type => "pattern", :pattern => '^[-+]?[0-9]\\d*$', :message => _("Must be an integer")},
-                          {:type => "min-number-value", :value => 1, :message => _('Must be greater than or equal to 1')}],
+          :component    => "text-field",
+          :id           => "size_GB",
+          :name         => "size_GB",
+          :label        => _("Size (GiB)"),
+          :isRequired   => true,
+          :validate     => [{:type => "required"},
+                            {:type => "pattern", :pattern => '^[-+]?[0-9]\\d*$', :message => _("Must be an integer")},
+                            {:type => "min-number-value", :value => 1, :message => _('Must be greater than or equal to 1')}],
           :initialValue => init_volume_size,
         }
       ]
@@ -119,5 +119,4 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
       ]
     }
   end
-
 end

--- a/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
@@ -56,12 +56,9 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
     EmsRefresh.queue_refresh(ext_management_system)
   end
 
-  def self.params_for_update(provider, params)
-    services = provider.storage_services.map { |service| {:value => service.id, :label => service.name} }
-    storage_service_id = ExtManagementSystem.find(params["ems_id"]).cloud_volumes.detect { |e| e.id.to_s == params["record_id"] }.storage_service_id
-    service_value = services.detect { |e| e[:value] == storage_service_id }[:label]
-
-    init_volume_size = (ExtManagementSystem.find(params["ems_id"]).cloud_volumes.detect { |e| e.id.to_s == params["record_id"] }.size / 1.0.gigabyte).round
+  def params_for_update
+    ems = ExtManagementSystem.find(ems_id)
+    service_value = ems.storage_services.detect { {:value => id, :label => name} }[:name]
 
     {
       :fields => [
@@ -84,7 +81,7 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
           :validate     => [{:type => "required"},
                             {:type => "pattern", :pattern => '^[-+]?[0-9]\\d*$', :message => _("Must be an integer")},
                             {:type => "min-number-value", :value => 1, :message => _('Must be greater than or equal to 1')}],
-          :initialValue => init_volume_size,
+          :initialValue => (size / 1.0.gigabyte).round,
         }
       ]
     }

--- a/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
@@ -8,7 +8,7 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
   def self.raw_create_volume(ext_management_system, options = {})
     # @type [StorageService]
     vol_to_create = ext_management_system.autosde_client.VolumeCreate(
-      :service => options["storage_service"],
+      :service => ExtManagementSystem.find(options["ems_id"]).storage_services.detect {|e| e.id.to_s ==  options["storage_service_id"]}.ems_ref,
       :name    => options["name"],
       :size    => options["size"]
     )
@@ -37,13 +37,11 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
   # ================= edit  ================
 
   def raw_update_volume(options = {})
-    ems = ext_management_system
-    update_details = ems.autosde_client.VolumeUpdate(
-      :name => options[:name],
-      :size => options[:size]
+    update_details = ext_management_system.autosde_client.VolumeUpdate(
+      :name => options["name"],
+      :size => options["size_GB"]
     )
-
-    ems.autosde_client.VolumeApi.volumes_pk_put(ems_ref, update_details)
+    ext_management_system.autosde_client.VolumeApi.volumes_pk_put(ems_ref, update_details)
     EmsRefresh.queue_refresh(ems)
   end
 
@@ -58,19 +56,55 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
     EmsRefresh.queue_refresh(ext_management_system)
   end
 
-  def self.params_for_create(provider)
-    services = provider.storage_services.map { |service| {:value => service.ems_ref, :label => service.name} }
+  def self.params_for_update(provider, params)
+    services = provider.storage_services.map { |service| {:value => service.id, :label => service.name} }
+    storage_service_id = ExtManagementSystem.find(params["ems_id"]).cloud_volumes.detect {|e| e.id.to_s ==  params["record_id"]}.storage_service_id
+    service_value = services.detect {|e| e[:value] ==   storage_service_id}[:label]
+
+    init_volume_size = (ExtManagementSystem.find(params["ems_id"]).cloud_volumes.detect {|e| e.id.to_s ==  params["record_id"]}.size / 1.0.gigabyte).round
+
     {
       :fields => [
         {
-          :component    => "select",
+          :component    => "text-field",
           :name         => "storage_service",
           :id           => "storage_service",
           :label        => _("Storage Pool"),
           :isRequired   => true,
           :validate     => [{:type => "required"}],
+          :initialValue => service_value,
+          :isDisabled   => true
+        },
+        {
+          :component  => "text-field",
+          :id         => "size_GB",
+          :name       => "size_GB",
+          :label      => _("Size (GiB)"),
+          :isRequired => true,
+          :validate   => [{:type => "required"},
+                          {:type => "pattern", :pattern => '^[-+]?[0-9]\\d*$', :message => _("Must be an integer")},
+                          {:type => "min-number-value", :value => 1, :message => _('Must be greater than or equal to 1')}],
+          :initialValue => init_volume_size,
+        }
+      ]
+    }
+  end
+
+  def self.params_for_create(provider)
+    services = provider.storage_services.map { |service| {:value => service.id, :label => service.name} }
+
+    {
+      :fields => [
+        {
+          :component    => "select",
+          :name         => "storage_service_id",
+          :id           => "storage_service_id",
+          :label        => _("Storage Pool"),
+          :isRequired   => true,
+          :validate     => [{:type => "required"}],
           :options      => services,
-          :includeEmpty => true
+          :includeEmpty => true,
+          :isDisabled   => false
         },
         {
           :component  => "text-field",
@@ -85,4 +119,5 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
       ]
     }
   end
+
 end

--- a/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
@@ -8,7 +8,7 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
   def self.raw_create_volume(ext_management_system, options = {})
     # @type [StorageService]
     vol_to_create = ext_management_system.autosde_client.VolumeCreate(
-      :service => ExtManagementSystem.find(options["ems_id"]).storage_services.detect { |e| e.id.to_s == options["storage_service_id"] }.ems_ref,
+      :service => ext_management_system.storage_services.find(options["storage_service_id"]).ems_ref,
       :name    => options["name"],
       :size    => options["size"]
     )
@@ -58,7 +58,8 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
 
   def params_for_update
     ems = ExtManagementSystem.find(ems_id)
-    service_value = ems.storage_services.detect { {:value => id, :label => name} }[:name]
+    storage_service_id = ems.cloud_volumes.find_by(:id => id)[:storage_service_id]
+    service_value = ems.storage_services.find_by(:id => storage_service_id)[:name]
 
     {
       :fields => [


### PR DESCRIPTION
This PR is part of PRs that solve Autosde cloud volume editing

![image](https://user-images.githubusercontent.com/53213107/125775465-d40dc87e-29a7-4aac-a032-2554801875ed.png)

If specific info about a cloud volume is passed then we are under update mode (not creation) and the update field should be used.


Links
----------------
https://github.com/ManageIQ/manageiq-ui-classic/pull/7788
https://github.com/ManageIQ/manageiq-api/pull/1056