### PR TITLE
Add status and host_cluster_name to host_initiators table

### DIFF
--- a/app/models/manageiq/providers/autosde/inventory/parser/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/inventory/parser/storage_manager.rb
@@ -71,9 +71,11 @@ class ManageIQ::Providers::Autosde::Inventory::Parser::StorageManager < ManageIQ
   def host_initiators
     collector.storage_hosts.each do |host_initiator|
       persister.host_initiators.build(
-        :name             => host_initiator.name,
-        :ems_ref          => host_initiator.uuid,
-        :physical_storage => persister.physical_storages.lazy_find(host_initiator.storage_system)
+        :name              => host_initiator.name,
+        :ems_ref           => host_initiator.uuid,
+        :physical_storage  => persister.physical_storages.lazy_find(host_initiator.storage_system),
+        :status            => host_initiator.status,
+        :host_cluster_name => host_initiator.host_cluster_name
       )
     end
   end


### PR DESCRIPTION
two fields were added to host initiators listing page:
- status
- host_cluster_name

![Screenshot 2021-07-28 150036](https://user-images.githubusercontent.com/53213107/127433149-73563b89-76a4-44a7-a69f-00967c7eb647.jpg)

links
--------
https://github.com/ManageIQ/manageiq-ui-classic/pull/7803 - need to be merged after this PR
https://github.com/ManageIQ/manageiq-schema/pull/594 - need to be merged before this PR