### PR TITLE
New feature - Editing physical storage

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
@@ -15,10 +15,10 @@ class ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage < ::Physical
 
   def raw_update_physical_storage(options = {})
     update_details = ext_management_system.autosde_client.StorageSystemUpdate(
-      :name           => options['name'],
-      :password       => options['password'] || "",
-      :user           => options['user'] || "",
-      :management_ip  => options['management_ip'] || "",
+      :name          => options['name'],
+      :password      => options['password'] || "",
+      :user          => options['user'] || "",
+      :management_ip => options['management_ip'] || ""
     )
     ext_management_system.autosde_client.StorageSystemApi.storage_systems_pk_put(ems_ref, update_details)
     EmsRefresh.queue_refresh(ems)

--- a/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
@@ -13,12 +13,12 @@ class ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage < ::Physical
     EmsRefresh.queue_refresh(ems)
   end
 
-  def raw_update_physical_storage(_options = {})
+  def raw_update_physical_storage(options = {})
     update_details = ext_management_system.autosde_client.StorageSystemUpdate(
-      :name           => _options['name'],
-      :password       => _options['password'] || "",
-      :user           => _options['user'] || "",
-      :management_ip  => _options['management_ip'] || "",
+      :name           => options['name'],
+      :password       => options['password'] || "",
+      :user           => options['user'] || "",
+      :management_ip  => options['management_ip'] || "",
     )
     ext_management_system.autosde_client.StorageSystemApi.storage_systems_pk_put(ems_ref, update_details)
     EmsRefresh.queue_refresh(ems)

--- a/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
@@ -1,5 +1,8 @@
 class ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage < ::PhysicalStorage
   supports :create
+  supports :update do
+    unsupported_reason_add(:update, _("The Physical Storage is not connected to an active Manager")) if ext_management_system.nil?
+  end
   supports :delete do
     unsupported_reason_add(:delete, _("The Physical Storage is not connected to an active Manager")) if ext_management_system.nil?
   end
@@ -7,6 +10,17 @@ class ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage < ::Physical
   def raw_delete_physical_storage
     ems = ext_management_system
     ems.autosde_client.StorageSystemApi.storage_systems_pk_delete(ems_ref)
+    EmsRefresh.queue_refresh(ems)
+  end
+
+  def raw_update_physical_storage(_options = {})
+    update_details = ext_management_system.autosde_client.StorageSystemUpdate(
+      :name           => _options['name'],
+      :password       => _options['password'] || "",
+      :user           => _options['user'] || "",
+      :management_ip  => _options['management_ip'] || "",
+    )
+    ext_management_system.autosde_client.StorageSystemApi.storage_systems_pk_put(ems_ref, update_details)
     EmsRefresh.queue_refresh(ems)
   end
 

--- a/spec/vcr_cassettes/bad_token_get_storage_systems_with_relogin_not_fails.yml
+++ b/spec/vcr_cassettes/bad_token_get_storage_systems_with_relogin_not_fails.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://9.151.190.208:9000/site-manager/api/v1/engine/storage-systems/
+    uri: http://9.151.190.208:9000/site-manager/api/v1/engine/storage-systems
     body:
       encoding: US-ASCII
       string: ''
@@ -80,7 +80,7 @@ http_interactions:
   recorded_at: Sat, 18 Jul 2020 14:45:18 GMT
 - request:
     method: get
-    uri: http://9.151.190.208:9000/site-manager/api/v1/engine/storage-systems/
+    uri: http://9.151.190.208:9000/site-manager/api/v1/engine/storage-systems
     body:
       encoding: US-ASCII
       string: ''
@@ -119,7 +119,7 @@ http_interactions:
   recorded_at: Sat, 18 Jul 2020 14:45:18 GMT
 - request:
     method: get
-    uri: https://autosde-appliance-host/site-manager/api/v1/engine/storage-systems/
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/storage-systems
     body:
       encoding: US-ASCII
       string: ''
@@ -201,7 +201,7 @@ http_interactions:
   recorded_at: Sun, 19 Jul 2020 10:50:22 GMT
 - request:
     method: get
-    uri: https://autosde-appliance-host/site-manager/api/v1/engine/storage-systems/
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/storage-systems
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/check_state_exists.yml
+++ b/spec/vcr_cassettes/check_state_exists.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://autosde-appliance-host/site-manager/api/v1/engine/token-auth/
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/token-auth
     body:
       encoding: UTF-8
       string: '{"username":"<username>","password":"<password>"}'
@@ -41,7 +41,7 @@ http_interactions:
   recorded_at: Sun, 28 Jun 2020 11:20:35 GMT
 - request:
     method: get
-    uri: https://autosde-appliance-host/site-manager/api/v1/engine/volumes/
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/volumes
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/create_new_volume.yml
+++ b/spec/vcr_cassettes/create_new_volume.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://autosde-appliance-host/site-manager/api/v1/engine/volumes/
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/volumes
     body:
       encoding: UTF-8
       string: '{"compliant":false,"name":"vol_test_bk_2020-06-28 14_20_35","service":"6ac78be9-d6cc-4c3f-8882-bec5e6be1dc3","size":10}'

--- a/spec/vcr_cassettes/ems_refresh.yml
+++ b/spec/vcr_cassettes/ems_refresh.yml
@@ -41,7 +41,7 @@ http_interactions:
   recorded_at: Thu, 07 Jan 2021 09:35:16 GMT
 - request:
     method: get
-    uri: https://autosde-appliance-host/site-manager/api/v1/engine/system-types/
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/system-types
     body:
       encoding: US-ASCII
       string: ''
@@ -125,7 +125,7 @@ http_interactions:
 
 - request:
     method: get
-    uri: https://autosde-appliance-host/site-manager/api/v1/engine/storage-systems/
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/storage-systems
     body:
       encoding: US-ASCII
       string: ''
@@ -166,7 +166,7 @@ http_interactions:
   recorded_at: Thu, 07 Jan 2021 09:35:16 GMT
 - request:
     method: get
-    uri: https://autosde-appliance-host/site-manager/api/v1/engine/storage-resources/
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/storage-resources
     body:
       encoding: US-ASCII
       string: ''
@@ -248,7 +248,7 @@ http_interactions:
   recorded_at: Thu, 07 Jan 2021 09:35:16 GMT
 - request:
     method: get
-    uri: https://autosde-appliance-host/site-manager/api/v1/engine/services/
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/services
     body:
       encoding: US-ASCII
       string: ''
@@ -289,7 +289,7 @@ http_interactions:
   recorded_at: Thu, 07 Jan 2021 09:35:16 GMT
 - request:
     method: get
-    uri: https://autosde-appliance-host/site-manager/api/v1/engine/volumes/
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/volumes
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/get_service_resource_attachment.yml
+++ b/spec/vcr_cassettes/get_service_resource_attachment.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://autosde-appliance-host/site-manager/api/v1/engine/service-resource-attchment/
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/service-resource-attchment
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/get_services.yml
+++ b/spec/vcr_cassettes/get_services.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://autosde-appliance-host/site-manager/api/v1/engine/services/
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/services
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/get_storage_resources.yml
+++ b/spec/vcr_cassettes/get_storage_resources.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://autosde-appliance-host/site-manager/api/v1/engine/storage-resources/
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/storage-resources
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/get_storage_system.yml
+++ b/spec/vcr_cassettes/get_storage_system.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://autosde-appliance-host/site-manager/api/v1/engine/token-auth/
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/token-auth
     body:
       encoding: UTF-8
       string: '{"username":"<username>","password":"<password>"}'
@@ -41,7 +41,7 @@ http_interactions:
   recorded_at: Sun, 28 Jun 2020 11:20:35 GMT
 - request:
     method: get
-    uri: https://autosde-appliance-host/site-manager/api/v1/engine/storage-systems/
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/storage-systems
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/get_storage_systems_autosde_client.yml
+++ b/spec/vcr_cassettes/get_storage_systems_autosde_client.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://autosde-appliance-host/site-manager/api/v1/engine/token-auth/
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/token-auth
     body:
       encoding: UTF-8
       string: '{"username":"<username>","password":"<password>"}'
@@ -41,7 +41,7 @@ http_interactions:
   recorded_at: Thu, 02 Jul 2020 09:49:02 GMT
 - request:
     method: get
-    uri: https://autosde-appliance-host/site-manager/api/v1/engine/storage-systems/
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/storage-systems
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/get_storage_systems_from_storage_manager.yml
+++ b/spec/vcr_cassettes/get_storage_systems_from_storage_manager.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://autosde-appliance-host/site-manager/api/v1/engine/token-auth/
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/token-auth
     body:
       encoding: UTF-8
       string: '{"username":"<username>","password":"<password>"}'
@@ -41,7 +41,7 @@ http_interactions:
   recorded_at: Mon, 13 Jul 2020 12:50:15 GMT
 - request:
     method: get
-    uri: https://autosde-appliance-host/site-manager/api/v1/engine/storage-systems/
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/storage-systems
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/get_volumes.yml
+++ b/spec/vcr_cassettes/get_volumes.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://autosde-appliance-host/site-manager/api/v1/engine/volumes/
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/volumes
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/get_volumes_after_creation.yml
+++ b/spec/vcr_cassettes/get_volumes_after_creation.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://autosde-appliance-host/site-manager/api/v1/engine/volumes/
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/volumes
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/incorrect_login_spec.yml
+++ b/spec/vcr_cassettes/incorrect_login_spec.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://autosde-appliance-host/site-manager/api/v1/engine/token-auth/
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/token-auth
     body:
       encoding: UTF-8
       string: '{"username":"<username>","password":"<password>"}'


### PR DESCRIPTION
This PR add new feature for physical-storages, the ability to edit an existing physical-storage. We can change the storage name and/or the storage credentials (management-ip, user and password)

![image](https://user-images.githubusercontent.com/53213107/130013313-306aeba4-75cf-4c5b-8fff-24ac8444f62a.png)

![image](https://user-images.githubusercontent.com/53213107/130013379-5d4a7254-80b0-4921-bf0c-4a598847d3e9.png)

![image](https://user-images.githubusercontent.com/53213107/130013441-f79260a6-30b5-4bbe-affb-c70b81e8c76d.png)


links
-----
https://github.com/ManageIQ/manageiq-ui-classic/pull/7836
https://github.com/ManageIQ/manageiq-api/pull/1066