### PR TITLE
added new supported items to EMS

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager.rb
@@ -9,6 +9,10 @@ class ManageIQ::Providers::Autosde::StorageManager < ManageIQ::Providers::Storag
   supports :cloud_volume_create
   supports :cloud_volume
 
+  supports :add_storage
+  supports :add_host_initiator
+  supports :add_volume_mapping
+
   include ManageIQ::Providers::StorageManager::BlockMixin
 
   # Asset details


### PR DESCRIPTION
This set of PRs is meant to limit some operations so that they can only be performed on EMSs that support them.
The operations in question all have to do with block-storage managers.
- Add a new storage-system to the EMS
- Add a new host-initiator to the EMS
- Add a new volume-mapping
Currently the only manger that supports these operations is the manageiq-providers-autosde. But there's nothing to stop users from trying to perform these operations on other block-storage managers, such as Cinder.

So we add features to represent these operations, and we filter by them in the UI-forms for the operations. 

Related PRs
https://github.com/ManageIQ/manageiq/pull/21387
https://github.com/ManageIQ/manageiq-ui-classic/pull/7837
https://github.com/ManageIQ/manageiq-providers-autosde/pull/77



The screenshot below shows one of the forms that would be affected.

![image](https://user-images.githubusercontent.com/68283004/130060008-724172f3-40a4-45c5-b2db-076c875760c7.png)


