### PR TITLE
Added minimum volume size validation on volume update

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
@@ -58,6 +58,7 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
   end
 
   def params_for_update
+    initialSize = (size / 1.0.gigabyte).round
     {
       :fields => [
         {
@@ -78,8 +79,8 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
           :isRequired   => true,
           :validate     => [{:type => "required"},
                             {:type => "pattern", :pattern => '^[-+]?[0-9]\\d*$', :message => _("Must be an integer")},
-                            {:type => "min-number-value", :value => 1, :message => _('Must be greater than or equal to 1')}],
-          :initialValue => (size / 1.0.gigabyte).round,
+                            {:type => "min-number-value", :value => initialSize, :message => _("Must be greater than or equal to %d" % [initialSize])}],
+          :initialValue => initialSize,
         }
       ]
     }

--- a/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
@@ -58,7 +58,7 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
   end
 
   def params_for_update
-    initialSize = (size / 1.0.gigabyte).round
+    initial_size = (size / 1.0.gigabyte).round
     {
       :fields => [
         {
@@ -79,8 +79,8 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
           :isRequired   => true,
           :validate     => [{:type => "required"},
                             {:type => "pattern", :pattern => '^[-+]?[0-9]\\d*$', :message => _("Must be an integer")},
-                            {:type => "min-number-value", :value => initialSize, :message => _("Must be greater than or equal to %d" % [initialSize])}],
-          :initialValue => initialSize,
+                            {:type => "min-number-value", :value => initial_size, :message => _("Must be greater than or equal to %d" % [initial_size])}],
+          :initialValue => initial_size,
         }
       ]
     }


### PR DESCRIPTION
We can't shrink volume size.
Changed volume size validation. Now the user can't submit a smaller size than the current volume size.
![image](https://user-images.githubusercontent.com/58298268/132648129-6d6cae8c-a2eb-4894-aee6-43f86cb657db.png)
