### PR TITLE
Add support for creating multiple host initiators wwpn

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/host_initiator.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/host_initiator.rb
@@ -2,12 +2,15 @@ class ManageIQ::Providers::Autosde::StorageManager::HostInitiator < ::HostInitia
   supports :create
 
   def self.raw_create_host_initiator(ext_management_system, options = {})
+    # wwpn values send to autosde should be format as colon separated string (e.g. WWPN1:WWPN2:WWPN3)
+    wwpn_values = options['wwpn'].join(":") if options['wwpn']
+
     host_initiator_to_create = ext_management_system.autosde_client.StorageHostCreate(
       :name           => options['name'],
       :port_type      => options['port_type'],
       :storage_system => PhysicalStorage.find(options['physical_storage_id']).ems_ref,
       :iqn            => options['iqn'] || "",
-      :wwpn           => options['wwpn'] || "",
+      :wwpn           => wwpn_values || "",
       :chap_name      => options['chap_name'] || "",
       :chap_secret    => options['chap_secret'] || ""
     )


### PR DESCRIPTION
Adding host initiator ability: create new host-initiator with  multiple wwpn for FC port

before:
![image](https://user-images.githubusercontent.com/53213107/134794682-e5f1678e-317d-421d-aa25-64569070254e.png)


after:
![image](https://user-images.githubusercontent.com/53213107/134336098-57957699-af8f-46e9-9450-3390c3668611.png)

links
------
https://github.com/ManageIQ/manageiq-ui-classic/pull/7858