### PR TITLE
ASDE-85 Fixed a bug in the new cloud-volume form

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
@@ -78,7 +78,7 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
   end
 
   def self.params_for_create(provider)
-    services = provider.storage_services.map { |service| {:value => service.id, :label => service.name} }
+    services = provider.storage_services.map { |service| {:value => service.id.to_s, :label => service.name} }
 
     {
       :fields => [


### PR DESCRIPTION
The bug is in the form for creating a new cloud-volume. The dropdown for picking the pool sometimes gets purged when one of the other fields is changed. See video below.
I'm not sure what the cause is, but looks like making sure that the options for the dropdown are all strings seems to fix the problem.

https://user-images.githubusercontent.com/68283004/136404957-3dcaa4cd-90aa-4a62-9f91-adae96f214d1.mp4

.
