### PR TITLE
fix ph-storage refresh

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
@@ -21,7 +21,7 @@ class ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage < ::Physical
       :management_ip => options['management_ip'] || ""
     )
     ext_management_system.autosde_client.StorageSystemApi.storage_systems_pk_put(ems_ref, update_details)
-    EmsRefresh.queue_refresh(ems)
+    EmsRefresh.queue_refresh(ext_management_system)
   end
 
   # @param [ManageIQ::Providers::Autosde] _ext_management_system


### PR DESCRIPTION
During ph_storage updating EmsRefresh.queue_refresh is called with undefined argument: ems

we need to set  ems = ext_management_system or just use ext_management_system  directly
