### PR TITLE
[MORPHY] set minor version for autosde_openapi_client gem

### DIFF
--- a/manageiq-providers-autosde.gemspec
+++ b/manageiq-providers-autosde.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "autosde_openapi_client", "~> 1.0"
+  spec.add_dependency "autosde_openapi_client", "~> 1.0.0"
   spec.add_dependency "typhoeus", "~> 1.4"
 
   spec.add_development_dependency "manageiq-style"


### PR DESCRIPTION
we started using version contorl for autosde_openapi_client gem.
the latest/master autosde-provider will be using version 1.1.x. older versions should use version 1.0.x.

we need to also backport this PR to lasker.

note
-----------
in the future we do want to set morphy to work with autosde_openapi_client gem version 1.1.x. in order to do it the following pr need to be backport to morphy:
https://github.com/ManageIQ/manageiq-providers-autosde/pull/99
