### PR TITLE
change default_manager_name in inventory to StorageManager

### DIFF
--- a/app/models/manageiq/providers/autosde/inventory.rb
+++ b/app/models/manageiq/providers/autosde/inventory.rb
@@ -5,8 +5,7 @@ class ManageIQ::Providers::Autosde::Inventory < ManageIQ::Providers::Inventory
 
   # Default manager for building collector/parser/persister classes
   # when failed to get class name from refresh target automatically
-  # todo: ask Adam if we can remove this
   def self.default_manager_name
-    "PhysicalInfraManager"
+    "StorageManager"
   end
 end


### PR DESCRIPTION
inventory default_manager_name is incorrect (our provider was initially part of the PhysicalInfraManager, I guess we missed this section when we change it to StorageManager). changed to StorageManager