### PR TITLE
Creation of host initiator group

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/host_initiator_group.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/host_initiator_group.rb
@@ -1,0 +1,12 @@
+class ManageIQ::Providers::Autosde::StorageManager::HostInitiatorGroup < ::HostInitiatorGroup
+  supports :create
+
+  def self.raw_create_host_initiator_group(ext_management_system, options = {})
+    host_initiator_group_to_create = ext_management_system.autosde_client.HostCluster(
+      :name           => options['name'],
+      :storage_system => PhysicalStorage.find(options['physical_storage_id']).ems_ref
+    )
+    ext_management_system.autosde_client.HostClusterApi.host_clusters_post(host_initiator_group_to_create)
+    EmsRefresh.queue_refresh(ext_management_system)
+  end
+end


### PR DESCRIPTION
In this set of PRs we will allow users to create new host-initiator-groups on their storage systems through MIQ.

Needs to be done after https://github.com/ManageIQ/manageiq-schema/pull/619

Part of https://github.com/ManageIQ/manageiq-providers-autosde/issues/108

![image](https://user-images.githubusercontent.com/68283004/143038710-7020280e-7251-4bdb-b268-3f02e4d45f23.png)

![image](https://user-images.githubusercontent.com/68283004/143039248-ee83b398-7ad2-4052-9c70-81bbdfabd1c8.png)
