### PR TITLE
Add targeted refresh specs

### DIFF
--- a/app/models/manageiq/providers/autosde/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/autosde/inventory/collector/target_collection.rb
@@ -67,7 +67,6 @@ class ManageIQ::Providers::Autosde::Inventory::Collector::TargetCollection < Man
       case target
       when PhysicalStorage
         add_target(:physical_storages, target.ems_ref)
-        add_target(:physical_storage_families, target.physical_storage_family.ems_ref)
       when CloudVolume
         physical_storage = target.storage_resource.physical_storage
 

--- a/app/models/manageiq/providers/autosde/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/autosde/inventory/collector/target_collection.rb
@@ -68,13 +68,7 @@ class ManageIQ::Providers::Autosde::Inventory::Collector::TargetCollection < Man
       when PhysicalStorage
         add_target(:physical_storages, target.ems_ref)
       when CloudVolume
-        physical_storage = target.storage_resource.physical_storage
-
         add_target(:cloud_volumes, target.ems_ref)
-        add_target(:storage_resources, target.storage_resource.ems_ref)
-        add_target(:storage_services, target.storage_service.ems_ref)
-        add_target(:physical_storages, physical_storage.ems_ref)
-        add_target(:physical_storage_families, physical_storage.physical_storage_family.ems_ref)
       end
     end
   end


### PR DESCRIPTION
Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/21582

TODO:
- [x] Test no targets
- [x] Test existing physical_storage target
- [x] Test new physical_storage 
- [x] Test existing cloud_volume target
- [x] Test new cloud_volume