### PR TITLE
Fixed a bug where it was impossible to create the provider

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager.rb
@@ -138,6 +138,10 @@ class ManageIQ::Providers::Autosde::StorageManager < ManageIQ::Providers::Storag
     end
   end
 
+  def self.supported_for_create?
+    true
+  end
+
   def console_supported?
     false
   end


### PR DESCRIPTION
A little while ago @kbrock removed the method `self.supported_for_create?` from the provider, as part of https://github.com/ManageIQ/manageiq-providers-autosde/pull/110

However, if we don't override this method, the base `self.supported_for_create?` returns `false` for our provider, because it can technically have a parent ems. 
```ruby
class ExtManagementSystem < ApplicationRecord
  def self.supported_for_create?
    !reflections.include?("parent_manager")
  end
```
This means that we can't create new instances of the provider through the GUI, since a call to `/api/providers` no longer lists our provider as supported.