### PR TITLE
[WIP] add end2end test for create ph_storage

### DIFF
--- a/spec/fixtures/json/physical_storage.json
+++ b/spec/fixtures/json/physical_storage.json
@@ -1,0 +1,7 @@
+{
+  "name"                       : "svc-178",
+  "password"                   : "<password>",
+  "user"                       : "<user>",
+  "physical_storage_family_id" : 123,
+  "management_ip"              : "9.151.159.178"
+}

--- a/spec/models/manageiq/providers/autosde/storage_manager/physical_storage_spec.rb
+++ b/spec/models/manageiq/providers/autosde/storage_manager/physical_storage_spec.rb
@@ -9,22 +9,17 @@ describe ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage do
   end
 
   let(:create_ph_storage_hash) do
-    {
-      "name"                       => "svc-178",
-      "password"                   => "<password>",
-      "user"                       => "<user>",
-      # "physical_storage_family_id" => PhysicalStorageFamily.first.id,
-      "physical_storage_family_id" => 123,
-      "management_ip"              => "9.151.159.178",
-    }
+    autosde_provider_json_path = File.join(ManageIQ::Providers::Autosde::Engine.root, 'spec', 'fixtures', 'json', 'physical_storage.json')
+    autosde_provider_json_file = File.read(autosde_provider_json_path)
+    JSON.parse(autosde_provider_json_file)
   end
 
   it "compare end2end create physical storage hash" do
-    end2end_json_path = Rails.root.join("spec", "fixtures", "end2end", "physical_storage.json").to_s
-    end2end_json_file = File.read(end2end_json_path)
-    end2end_create_ph_storage_hash = JSON.parse(end2end_json_file)
+    ui_classic_json_path = File.join(ManageIQ::UI::Classic::Engine.root, 'spec', 'javascripts', 'fixtures', 'json', 'physical_storage.json')
+    ui_classic_json_file = File.read(ui_classic_json_path)
+    ui_classic_create_ph_storage_hash = JSON.parse(ui_classic_json_file)
 
-    expect(end2end_create_ph_storage_hash).to eq(create_ph_storage_hash)
+    expect(create_ph_storage_hash).to eq(ui_classic_create_ph_storage_hash)
   end
 
   it "create physical storage" do

--- a/spec/models/manageiq/providers/autosde/storage_manager/physical_storage_spec.rb
+++ b/spec/models/manageiq/providers/autosde/storage_manager/physical_storage_spec.rb
@@ -1,0 +1,37 @@
+require 'json'
+
+describe ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage do
+
+  let(:ems) do
+    FactoryBot.create(:autosde_storage_manager,
+                      :with_autosde_credentials,
+                      :hostname => Rails.application.secrets.autosde[:appliance_host])
+  end
+
+  let(:create_ph_storage_hash) do
+    {
+      "name"                       => "svc-178",
+      "password"                   => "<password>",
+      "user"                       => "<user>",
+      # "physical_storage_family_id" => PhysicalStorageFamily.first.id,
+      "physical_storage_family_id" => 123,
+      "management_ip"              => "9.151.159.178",
+    }
+  end
+
+  it "compare end2end create physical storage hash" do
+    end2end_json_path = Rails.root.join("spec", "fixtures", "end2end", "physical_storage.json").to_s
+    end2end_json_file = File.read(end2end_json_path)
+    end2end_create_ph_storage_hash = JSON.parse(end2end_json_file)
+
+    expect(end2end_create_ph_storage_hash).to eq(create_ph_storage_hash)
+  end
+
+  it "create physical storage" do
+    FactoryBot.create(:PhysicalStorageFamily, :name => "FlashSystems/SVC", :id => 123)
+
+    VCR.use_cassette("create_physical_storage", :record => :once) do
+      PhysicalStorage.create_physical_storage(ems.id, create_ph_storage_hash)
+    end
+  end
+end

--- a/spec/vcr_cassettes/create_physical_storage.yml
+++ b/spec/vcr_cassettes/create_physical_storage.yml
@@ -1,0 +1,83 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/token-auth
+    body:
+      encoding: UTF-8
+      string: '{"password":"<password>","username":"<username>"}'
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/1.1.2/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - "*/*"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 15 Dec 2021 11:49:55 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Allow:
+      - POST, OPTIONS
+      Vary:
+      - Accept
+      X-Frame-Options:
+      - SAMEORIGIN
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"token":"249f19445db50ae084bbe59fc9716c4b9dd4c93e"}'
+    http_version: null
+  recorded_at: Wed, 15 Dec 2021 11:49:55 GMT
+- request:
+    method: post
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/storage-systems
+    body:
+      encoding: UTF-8
+      string: '{"auto_add_pools":true,"auto_setup":true,"management_ip":"9.151.159.178","name":"svc-178","password":"<password>","storage_family":"ontap_7mode","system_type":"FlashSystems/SVC","user":"<user>"}'
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/1.1.2/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - "*/*"
+      Authorization:
+      - Bearer 249f19445db50ae084bbe59fc9716c4b9dd4c93e
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 15 Dec 2021 11:49:55 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"auto_add_pools":true,"component_state":"CREATED","management_ip":"9.151.159.178","name":"svc-178","status":null,"storage_array":null,"storage_family":"ontap_7mode","system_type":{"component_state":"PENDING_CREATION","name":"FlashSystems/SVC","short_version":"1","uuid":"bba8eb17-0e7f-4c02-90a3-5216ea05e306","version":"1.1"},"uuid":"9f25f501-d876-404f-8e7c-8a1c886b8edb"}'
+    http_version: null
+  recorded_at: Wed, 15 Dec 2021 11:49:55 GMT
+recorded_with: VCR 5.1.0


### PR DESCRIPTION
Since MIQ has no system-tests, we have been toying with an idea of simulating system tests by stitching unit tests back-to-back.

below are a set of PR with a very basic POC demonstrating the idea.
https://github.com/ManageIQ/manageiq/pull/21622
https://github.com/ManageIQ/manageiq-providers-autosde/pull/122
https://github.com/ManageIQ/manageiq-ui-classic/pull/7993


general outline of the approach
------------
Usually when someone submits a PR, they only run unit-tests in the repo that they changed. However, the change might affect flows in other repositories. 
In the POC we have a scenario where we create a new Physical Storage. It involves filling a JS form. The data from the form is submitted through the API to the appropriate create method in the backend, and the backend sends a request to the EMS. 
To cover this scenario we would write two tests. 
One in the UI would check that the form’s state matches what we need to send to the API. 
In the backend, we’d check that calling the create method of the controller with the correct parameters results in the correct API calls to the EMS. 
This would cover the end-to-end scenario but have a problem. 
If anyone were to change the backend, they’d adjust the tests for the backend but would not know to adjust the complementary tests for the UI. The two tests covering the scenario would drift apart over time and no longer cover a coherent flow. 
To overcome this, we couple the backend test to the UI form test through a separate set of tests. It these meta-tests make sure that the UI test’s state matches the input to the backend test. 
This way if anyone changes either the backend or the UI they will need to make sure the entire scenario still works. 

