### PR TITLE
Remove unused scopes from volume_mapping

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/volume_mapping.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/volume_mapping.rb
@@ -2,12 +2,6 @@ class ManageIQ::Providers::Autosde::StorageManager::VolumeMapping < ::VolumeMapp
   HOST_MAPPING_OBJECT = 'host'.freeze
   HOST_GROUP_MAPPING_OBJECT = 'host_group'.freeze
 
-  scope :to_clusters,  -> { where("type LIKE ?", "%Cluster%") }
-  scope :to_hosts,     -> { where("type LIKE ?", "%Host%") }
-
-  scope :to_clusters,  -> { where("type LIKE ?", "%Cluster%") }
-  scope :to_hosts,     -> { where("type LIKE ?", "%Host%") }
-
   supports :create
 
   supports :delete do


### PR DESCRIPTION
These were added originally to differentiate between a cluster and a host volume_mapping but it was (correctly) replaced by using STI.

These are now unused and can be deleted.