### PR TITLE
disabling cloud volume delete functionallity for autosde volumes

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
@@ -1,14 +1,12 @@
 class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
   supports :create
-  supports :delete do
-    unsupported_reason_add(:delete, _("the volume is not connected to an active provider")) unless ext_management_system
-  end
-  supports :safe_delete do
-    unsupported_reason_add(:safe_delete, _("the volume is not connected to an active provider")) unless ext_management_system
-  end
   supports :update do
     unsupported_reason_add(:update, _("the volume is not connected to an active provider")) unless ext_management_system
   end
+
+  # cloud volume delete functionality is not supported for now
+  supports_not :delete
+  supports_not :safe_delete
 
   def self.raw_create_volume(ext_management_system, options = {})
     # @type [StorageService]


### PR DESCRIPTION
autosde provider does not currently supports volume deletion.

before
---
![image](https://user-images.githubusercontent.com/53213107/152674689-22685871-0343-4afa-8fef-dd4d95edee0a.png)
![image](https://user-images.githubusercontent.com/53213107/152674707-5808dd1f-fe4e-42ef-9577-a8b44c685001.png)


after
---
![image](https://user-images.githubusercontent.com/53213107/152674553-fc3b721a-eedf-4685-b761-46db7db488b4.png)
![image](https://user-images.githubusercontent.com/53213107/152674558-9c121a8c-c5ca-4510-a321-b8a45f30f54d.png)


links
----
https://github.com/ManageIQ/manageiq-ui-classic/pull/8106
