### PR TITLE
Remove name field from ph_storage add page

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
@@ -27,7 +27,6 @@ class ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage < ::Physical
   # @param [ManageIQ::Providers::Autosde] _ext_management_system
   def self.raw_create_physical_storage(_ext_management_system, _options = {})
     sys_to_create = _ext_management_system.autosde_client.StorageSystemCreate(
-      :name           => _options['name'],
       :password       => _options['password'],
       :user           => _options['user'],
       :system_type    => PhysicalStorageFamily.find(_options['physical_storage_family_id']).name,


### PR DESCRIPTION
physical storage name is populate from REST API response from the storage manager (e.g. autosde) and shouldnt be entered by the user. 
The name field was therefore removed from add form, and disabled from edit form.

before
----
![1](https://user-images.githubusercontent.com/53213107/157213514-639587ae-12d9-4658-994b-fbfc80b89568.jpg)

![2](https://user-images.githubusercontent.com/53213107/157213566-2524237a-bc54-42ee-a0c1-a683eaa059d9.jpg)

after
---

![6](https://user-images.githubusercontent.com/53213107/157213686-17d1f6f5-9941-4e6d-8d3f-497d903019d5.jpg)

![4](https://user-images.githubusercontent.com/53213107/157213728-6776e67c-b2a5-4fa7-8164-d490868ff9aa.jpg)


links
----
https://github.com/ManageIQ/manageiq-ui-classic/pull/8161

