### PR TITLE
set storage resources size unit to GB instead of bytes

### DIFF
--- a/app/models/manageiq/providers/autosde/inventory/parser/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/inventory/parser/storage_manager.rb
@@ -49,8 +49,8 @@ class ManageIQ::Providers::Autosde::Inventory::Parser::StorageManager < ManageIQ
       persister.storage_resources.build(
         :name             => resource.name,
         :ems_ref          => resource.uuid,
-        :logical_free     => resource.logical_free,
-        :logical_total    => resource.logical_total,
+        :logical_free     => resource.logical_free / (1024 * 1024 * 1024),
+        :logical_total    => resource.logical_total / (1024 * 1024 * 1024),
         :physical_storage => persister.physical_storages.lazy_find(resource.storage_system)
       )
     end

--- a/spec/models/manageiq/providers/autosde/storage_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/autosde/storage_manager/refresher_spec.rb
@@ -258,7 +258,7 @@ describe ManageIQ::Providers::Autosde::StorageManager::Refresher do
       expect(storage_resource).to have_attributes(
         :name             => "9.151.159.178:ilyak_test_pool",
         :ems_ref          => "e6833c27-374b-4a4a-8d76-455cfe5f4270",
-        :logical_free     => 601_295_421_440,
+        :logical_free     => 560,
         :logical_total    => 0,
         :physical_storage => ems.physical_storages.find_by(:ems_ref => "980f3ceb-c599-49c4-9db3-fdc793cb8666"),
         :type             => "ManageIQ::Providers::Autosde::StorageManager::StorageResource"


### PR DESCRIPTION
Description
------
When we click on Storage->Storage Resources the list of storage resources shows the Total Size and Free Space in Bytes. From a User experience perspective, displaying them in TB or GB would be ideal as the storage allocated will be always larger in size and showing them in bytes does not help


Acceptance Criteria
-----
The Total Size and Free Space values in the list must be displayed in GB's or TB's instead of Bytes 


Business Justification
-----
User experience


before
-----
![2](https://user-images.githubusercontent.com/53213107/158346957-6f0cc1ef-fa9b-467a-8f67-9b13d1386214.jpg)

![3](https://user-images.githubusercontent.com/53213107/158346969-213b6b93-3485-444a-827d-0f1c3a8487df.jpg)


after
-----
![1](https://user-images.githubusercontent.com/53213107/158346826-ade9dce6-6e3c-4a76-b672-be7f3207e582.jpg)

![4](https://user-images.githubusercontent.com/53213107/158346920-a75fcfad-7c5a-4ed3-9712-be03ace95d64.jpg)

links
-----
https://github.com/ManageIQ/manageiq-ui-classic/pull/8176

