### PR TITLE
add rescue to AutosdeOpenapiClient::ApiError

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/autosde_client.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/autosde_client.rb
@@ -71,7 +71,7 @@ class ManageIQ::Providers::Autosde::StorageManager::AutosdeClient < AutosdeOpena
     @token = data.token
   rescue AutosdeOpenapiClient::ApiError => e
     error_data = JSON.parse(e.response_body)
-    raise AUTH_ERRR_MSG + error_data['detail']['non_field_errors'][0]
+    raise AUTH_ERRR_MSG + error_data.dig("detail", "non_field_errors")&.first
   rescue => e
     raise AUTH_ERRR_MSG + e.to_s
   end


### PR DESCRIPTION
Improve the get method of the error message from the Autosde response.