### PR TITLE
del host initiator

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/host_initiator.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/host_initiator.rb
@@ -1,5 +1,6 @@
 class ManageIQ::Providers::Autosde::StorageManager::HostInitiator < ::HostInitiator
   supports :create
+  supports :delete
 
   def self.raw_create_host_initiator(ext_management_system, options = {})
     wwpns = Array(options['custom_wwpn'])
@@ -20,5 +21,10 @@ class ManageIQ::Providers::Autosde::StorageManager::HostInitiator < ::HostInitia
 
     ext_management_system.autosde_client.StorageHostApi.storage_hosts_post(host_initiator_to_create)
     EmsRefresh.queue_refresh(ext_management_system)
+  end
+  def raw_delete_host_initiator
+    ems = ext_management_system
+    ems.autosde_client.StorageHostApi.storage_hosts_pk_delete(ems_ref)
+    EmsRefresh.queue_refresh(self)
   end
 end

--- a/app/models/manageiq/providers/autosde/storage_manager/host_initiator.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/host_initiator.rb
@@ -22,9 +22,10 @@ class ManageIQ::Providers::Autosde::StorageManager::HostInitiator < ::HostInitia
     ext_management_system.autosde_client.StorageHostApi.storage_hosts_post(host_initiator_to_create)
     EmsRefresh.queue_refresh(ext_management_system)
   end
+
   def raw_delete_host_initiator
     ems = ext_management_system
     ems.autosde_client.StorageHostApi.storage_hosts_pk_delete(ems_ref)
-    EmsRefresh.queue_refresh(self)
+    EmsRefresh.queue_refresh(ems)
   end
 end


### PR DESCRIPTION
This PR add new feature for host-initiators (storage), the ability to **delete an existing host-initiator**.

<img width="884" alt="Screen Shot 2022-05-03 at 13 40 41" src="https://user-images.githubusercontent.com/6840118/166441274-073a8d0c-6a8c-4030-9123-85245a50b6fb.png">

<img width="858" alt="Screen Shot 2022-05-03 at 13 41 08" src="https://user-images.githubusercontent.com/6840118/166441293-54baa577-abc5-41e8-99af-b2cee3b877d0.png">


Links
----------------
* https://github.com/ManageIQ/manageiq-ui-classic/pull/8249
* https://github.com/ManageIQ/manageiq/pull/21845
* https://github.com/ManageIQ/manageiq-api/pull/1157