### PR TITLE
implemented validation storage system button

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
@@ -14,23 +14,13 @@ class ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage < ::Physical
   end
 
   def self.raw_validate_physical_storage(ext_management_system, options = {})
-    header_params = options[:header_params] || {}
-    header_params['Accept'] = ext_management_system.autosde_client.select_header_accept(['*/*'])
-    header_params['Content-Type'] = ext_management_system.autosde_client.select_header_content_type(['application/json'])
-
-    request_opts = {
-      :header_params => header_params,
-      :body => options.merge(
-        :system_type => PhysicalStorageFamily.find(options['physical_storage_family_id']).name,
-      ),
-      :auth_names => ['bearerAuth'],
-    }
-
-    data, status_code, headers = ext_management_system.autosde_client.call_api(:POST, 'validate-system', request_opts)
-    if ext_management_system.autosde_client.config.debugging
-      ext_management_system.autosde_client.config.logger.debug "API called: StorageSystemValidation#storage_systems_post\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
-    end
-    return data, status_code, headers
+    validation_object = ext_management_system.autosde_client.StorageSystemCreate(
+      :management_ip => options['management_ip'],
+      :user          => options['user'],
+      :password      => options['password'],
+      :system_type   => PhysicalStorageFamily.find(options['physical_storage_family_id']).name
+    )
+    ext_management_system.autosde_client.ValidateSystemApi.validate_system_post(validation_object)
   end
 
   def raw_update_physical_storage(options = {})

--- a/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
@@ -13,6 +13,26 @@ class ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage < ::Physical
     EmsRefresh.queue_refresh(self)
   end
 
+  def self.raw_validate_physical_storage(ext_management_system, options = {})
+    header_params = options[:header_params] || {}
+    header_params['Accept'] = ext_management_system.autosde_client.select_header_accept(['*/*'])
+    header_params['Content-Type'] = ext_management_system.autosde_client.select_header_content_type(['application/json'])
+
+    request_opts = {
+      :header_params => header_params,
+      :body => options.merge(
+        :system_type => PhysicalStorageFamily.find(options['physical_storage_family_id']).name,
+      ),
+      :auth_names => ['bearerAuth'],
+    }
+
+    data, status_code, headers = ext_management_system.autosde_client.call_api(:POST, 'validate-system', request_opts)
+    if ext_management_system.autosde_client.config.debugging
+      ext_management_system.autosde_client.config.logger.debug "API called: StorageSystemValidation#storage_systems_post\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+    end
+    return data, status_code, headers
+  end
+
   def raw_update_physical_storage(options = {})
     update_details = ext_management_system.autosde_client.StorageSystemUpdate(
       :name          => options['name'],


### PR DESCRIPTION
# Description
We implemented a 'validate-storage' rest API on the AutoSDE side to have the ability to validate the storage system credentials before we send the creation task to the queue. With this feature, we're saving time and can change the credentials (if there are provided some invalid parameters) without waiting for the response of the queued task.
I implemented the validate button on the attaching storage system page. So we can press the button and validate that the provided parameters are valid. If they are valid, AutoSDE saved this validation request and when we'll press the submit button, the queue task will not validate another time but just take the object that has been created by the previous validation request.

# Illustration video
![validate-button](https://user-images.githubusercontent.com/33315712/170862025-b21a66e4-b01c-42da-b8d5-eb1b01eec873.gif)

# Links
https://github.com/ManageIQ/manageiq/pull/21882
https://github.com/ManageIQ/manageiq-ui-classic/pull/8279
https://github.com/ManageIQ/manageiq-api/pull/1163
