### PR TITLE
Added necessary supports command

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
@@ -6,6 +6,7 @@ class ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage < ::Physical
   supports :delete do
     unsupported_reason_add(:delete, _("The Physical Storage is not connected to an active Manager")) if ext_management_system.nil?
   end
+  supports :validate
 
   def raw_delete_physical_storage
     ems = ext_management_system


### PR DESCRIPTION
As part of the implementation of the new validation physical storage button. I need to add this 'supports :validate' command in order to use the 'supports' method in manageiq-api branch.

# linked repos:
- https://github.com/ManageIQ/manageiq-api/pull/1163
- https://github.com/ManageIQ/manageiq-ui-classic/pull/8279
- https://github.com/ManageIQ/manageiq-api/pull/1167