### PR TITLE
EventCatcher worker for Physical Storage

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager.rb
@@ -11,6 +11,7 @@ class ManageIQ::Providers::Autosde::StorageManager < ManageIQ::Providers::Storag
   require_nested :StorageResource
   require_nested :StorageService
   require_nested :VolumeMapping
+  require_nested :EventCatcher
 
   supports :create
   supports :storage_services

--- a/app/models/manageiq/providers/autosde/storage_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/event_catcher.rb
@@ -1,0 +1,4 @@
+class ManageIQ::Providers::Autosde::StorageManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
+  require_nested :Runner
+  require_nested :Stream
+end

--- a/app/models/manageiq/providers/autosde/storage_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/event_catcher/runner.rb
@@ -1,0 +1,45 @@
+class ManageIQ::Providers::Autosde::StorageManager::EventCatcher::Runner < ManageIQ::Providers::BaseManager::EventCatcher::Runner
+  def event_monitor_handle
+    @event_monitor_handle ||= self.class.parent::Stream.new(@ems)
+  end
+
+  def reset_event_monitor_handle
+    @autosde_client = nil
+  end
+
+  def stop_event_monitor
+    event_monitor_handle.stop
+  end
+
+  def monitor_events
+    event_monitor_handle.start
+
+    event_monitor_running
+
+    event_monitor_handle.poll_events do |event|
+      @queue.enq(event)
+    end
+  ensure
+    stop_event_monitor
+  end
+
+  def queue_event(event)
+    _log.info("#{log_prefix} Caught event AutoSDE [#{event.event_id}]")
+    event_hash = event_to_hash(event, @cfg[:ems_id])
+    EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
+  end
+
+  private
+
+  def event_to_hash(event, ems_id)
+    {
+      :event_type => event.event_type,
+      :source     => "AUTOSDE",
+      :ems_ref    => event.event_id,
+      :timestamp  => event.last_timestamp,
+      :full_data  => event.to_hash,
+      :ems_id     => ems_id,
+      :message    => event.description
+    }
+  end
+end

--- a/app/models/manageiq/providers/autosde/storage_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/event_catcher/stream.rb
@@ -1,0 +1,29 @@
+class ManageIQ::Providers::Autosde::StorageManager::EventCatcher::Stream
+  attr_reader :ems, :stop_polling, :poll_sleep
+
+  def initialize(ems, options = {})
+    @ems = ems
+    @autosde_client ||= @ems.autosde_client.EventApi
+    @stop_polling = false
+    @poll_sleep = options[:poll_sleep] || 20.seconds
+  end
+
+  def start
+    @stop_polling = false
+  end
+
+  def stop
+    @stop_polling = true
+  end
+
+  def poll_events(&block)
+    loop do
+      events = @autosde_client.events_get
+
+      break if stop_polling
+
+      events.each(&block)
+      sleep(poll_sleep)
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,6 +3,9 @@
     :blacklisted_event_names: []
     :event_handling:
       :event_groups:
+        :general:
+          :critical:
+            - autosde_critical_alert
         :power:
           :critical:
             - AUTOSDE_instance_power_on
@@ -15,6 +18,9 @@
     :user:
 :workers:
   :worker_base:
+    :event_catcher:
+      :event_catcher_autosde:
+        :poll: 15.seconds
     :queue_worker_base:
       :ems_refresh_worker:
         :ems_refresh_worker_autosde: {}

--- a/systemd/manageiq-providers-autosde_storage_manager_event_catcher.target
+++ b/systemd/manageiq-providers-autosde_storage_manager_event_catcher.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=manageiq.target

--- a/systemd/manageiq-providers-autosde_storage_manager_event_catcher@.service
+++ b/systemd/manageiq-providers-autosde_storage_manager_event_catcher@.service
@@ -1,0 +1,13 @@
+[Unit]
+PartOf=manageiq-providers-autosde_storage_manager_event_catcher.target
+[Install]
+WantedBy=manageiq-providers-autosde_storage_manager_event_catcher.target
+[Service]
+WorkingDirectory=/var/www/miq/vmdb
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+EnvironmentFile=/etc/default/manageiq*.properties
+ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Autosde::StorageManager::EventCatcher --heartbeat --guid=%i
+User=manageiq
+Restart=no
+Type=notify
+Slice=manageiq-providers-autosde_storage_manager_event_catcher.slice


### PR DESCRIPTION
We decided to import critical alerts from the physical storage into MIQ, catch them by a new listener worker, store them in the queue and convert them to EventStream objects so we'll be able to define Physical Storage Alerts and show them on the monitor page.

I've already implemented the EventCatcher, and Stream and configured the necessary files accordingly.
This worker should work as a service and pull our events from AutoSDE every 15 seconds.

