### PR TITLE
display events for physical storage

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/event_catcher/runner.rb
@@ -33,13 +33,14 @@ class ManageIQ::Providers::Autosde::StorageManager::EventCatcher::Runner < Manag
 
   def event_to_hash(event, ems_id)
     {
-      :event_type => event.event_type,
-      :source     => "AUTOSDE",
-      :ems_ref    => event.event_id,
-      :timestamp  => event.last_timestamp,
-      :full_data  => event.to_hash,
-      :ems_id     => ems_id,
-      :message    => event.description
+      :event_type               => event.event_type,
+      :source                   => "AUTOSDE",
+      :ems_ref                  => event.event_id,
+      :physical_storage_ems_ref => event.storage_system,
+      :timestamp                => event.created_at,
+      :full_data                => event.to_hash,
+      :ems_id                   => ems_id,
+      :message                  => event.description
     }
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,11 +3,9 @@
     :blacklisted_event_names: []
     :event_handling:
       :event_groups:
-        :general:
-          :critical:
-            - autosde_critical_alert
         :power:
           :critical:
+            - autosde_critical_alert
             - AUTOSDE_instance_power_on
             - AUTOSDE_instance_power_off
 :http_proxy:


### PR DESCRIPTION
* Following this PR: https://github.com/ManageIQ/manageiq-providers-autosde/pull/151
This is an implementation of the monitoring page for physical storage where we'll show our critical alerts (storage events).

Before:
![image](https://user-images.githubusercontent.com/33315712/180793645-fbba6ec8-fdb6-425c-9028-123cf77961df.png)

After:
![image](https://user-images.githubusercontent.com/33315712/180792764-f926449c-d76a-4aca-ae34-da2110fb7f11.png)

# related PRs:
- https://github.com/ManageIQ/manageiq-schema/pull/656
- https://github.com/ManageIQ/manageiq/pull/22008
- https://github.com/ManageIQ/manageiq-ui-classic/pull/8373