### PR TITLE
fixed edit cloud not working

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
@@ -40,8 +40,8 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
 
   def raw_update_volume(options = {})
     update_details = ext_management_system.autosde_client.VolumeUpdate(
-      :name => options["name"],
-      :size => options["size_GB"]
+      :name => options[:name],
+      :size => options[:size_GB]
     )
     ext_management_system.autosde_client.VolumeApi.volumes_pk_put(ems_ref, update_details)
     queue_refresh


### PR DESCRIPTION
someone changed edit_resource a few months ago inside `manageiq\plugins\manageiq-providers-autosde\app\models\manageiq\providers\autosde\storage_manager\physical_storage.rb` and now we pass symbols instead of keys.

We modified the `raw_update_volume` from `@name => options["name"]` to `@name => options[:name]` in order for it to work.