### PR TITLE
Fix autosde overwriting generic catalog type

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager.rb
@@ -294,6 +294,6 @@ class ManageIQ::Providers::Autosde::StorageManager < ManageIQ::Providers::Storag
   end
 
   def self.catalog_types
-    {"generic" => N_("Autosde")}
+    {"autosde" => N_("Autosde")}
   end
 end


### PR DESCRIPTION
Fix for AutoSDE overwriting the generic catalog type, https://github.com/ManageIQ/manageiq/runs/7677948424?check_suite_focus=true#step:8:317