### PR TITLE
change names of calls to StorageHostsMappingApi

### DIFF
--- a/app/models/manageiq/providers/autosde/inventory/collector/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/inventory/collector/storage_manager.rb
@@ -16,7 +16,7 @@ class ManageIQ::Providers::Autosde::Inventory::Collector::StorageManager < Manag
   end
 
   def host_volume_mappings
-    @host_volume_mappings ||= @manager.autosde_client.StorageHostVolumeMappingApi.storage_hosts_mapping_get
+    @host_volume_mappings ||= @manager.autosde_client.StorageHostsMappingApi.storage_hosts_mapping_get
   end
 
   def cluster_volume_mappings

--- a/app/models/manageiq/providers/autosde/storage_manager/volume_mapping.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/volume_mapping.rb
@@ -9,7 +9,7 @@ class ManageIQ::Providers::Autosde::StorageManager::VolumeMapping < ::VolumeMapp
   end
 
   def raw_delete_volume_mapping
-    ext_management_system.autosde_client.StorageHostVolumeMappingApi.storage_hosts_mapping_pk_delete(ems_ref)
+    ext_management_system.autosde_client.StorageHostsMappingApi.storage_hosts_mapping_pk_delete(ems_ref)
     EmsRefresh.queue_refresh(ext_management_system)
   end
 
@@ -22,11 +22,11 @@ class ManageIQ::Providers::Autosde::StorageManager::VolumeMapping < ::VolumeMapp
     volume_ref = CloudVolume.find(options['cloud_volume_id']).ems_ref
     case options['mapping_object']
     when HOST_MAPPING_OBJECT
-      host_volume_mapping_to_create = ext_management_system.autosde_client.StorageHostVolumeMappingCreate(
+      host_volume_mapping_to_create = ext_management_system.autosde_client.StorageHostsMappingCreate(
         :host   => HostInitiator.find(options['host_initiator_id']).ems_ref,
         :volume => volume_ref
       )
-      ext_management_system.autosde_client.StorageHostVolumeMappingApi.storage_hosts_mapping_post(host_volume_mapping_to_create)
+      ext_management_system.autosde_client.StorageHostsMappingApi.storage_hosts_mapping_post(host_volume_mapping_to_create)
     when HOST_GROUP_MAPPING_OBJECT
       cluster_volume_mapping_to_create = ext_management_system.autosde_client.HostClusterVolumeMappingCreate(
         :cluster => HostInitiatorGroup.find(options['host_initiator_group_id']).ems_ref,

--- a/manageiq-providers-autosde.gemspec
+++ b/manageiq-providers-autosde.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "autosde_openapi_client", "~> 1.1.0"
+  spec.add_dependency "autosde_openapi_client", "~> 1.2.0"
   spec.add_dependency "typhoeus", "~> 1.4"
 
   spec.add_development_dependency "manageiq-style"


### PR DESCRIPTION
The name of a class and a model in the oas client has changed, so when calling to the old name, an error is raised.

StorageHostVolumeMappingApi -> StorageHostsMappingApi
StorageHostVolumeMapping -> StorageHostsMapping
StorageHostVolumeMappingCreate -> StorageHostsMappingCreate

I changed the calls to the api and models to fix it in the two files where it is relevant
![errorMappingApiCall](https://user-images.githubusercontent.com/50288766/185115329-55dba598-f88a-4bc1-b63d-0d3ae71f2549.jpeg)
.