### PR TITLE
[WIP] Replace GIT with PATH in Gemfile.lock

### DIFF
--- a/bin/before_install
+++ b/bin/before_install
@@ -18,3 +18,14 @@ elif [ ! -d "$spec_manageiq" ]; then
   echo "== Cloning manageiq sample app =="
   git clone https://github.com/ManageIQ/manageiq.git --branch master --depth 1 "$spec_manageiq"
 fi
+
+if [ -n "$CI" ]; then
+  # Gemfile.lock.release only applies to non-master branches and PRs to non-master branches
+  if [[ "$GITHUB_REPOSITORY_OWNER" = "ManageIQ" && "$GITHUB_BASE_REF" != "master" && "$GITHUB_REF_NAME" != "master" && "$GITHUB_REF_NAME" != "dependabot/"* ]]; then
+    echo "== Setup Gemfile.lock.release =="
+    cp -f "$spec_manageiq/Gemfile.lock.release" "$gem_root/Gemfile.lock"
+
+    $spec_manageiq/bin/ci/patch_plugin_gemfile_lock
+    echo
+  fi
+fi


### PR DESCRIPTION
Prevent the Gemfile.lock from being rebuilt because of the change from a GIT reference to a PATH reference when bundling a plugin

When we use the `Gemfile.lock.release` from a core release branch then bundle install the `GIT` gem for the plugin currently being used is replaced by a `PATH` reference.  This unlocks the dependent gems and allows them to be updated which we don't want.

If we manually replace the specific plugin we are testing and leave the rest of the Gemfile.lock alone then the original gem versions are maintained.

VERY WIP

I used a little ruby script to do this for now, I believe I can get this to work with an awk state machine but it will take some time.
A state machine like `/GIT\n  remote: .+manageiq-providers-autosde/, /specs:/ {}` should allow us to print what we want changed between the start-pattern and end-pattern.

TODO:
- [ ] replace ruby with awk (?)
- [ ] parameterize the repo url