### PR TITLE
Set the event field  of PhysicalStorage as the physical-storage name

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/event_catcher/runner.rb
@@ -34,7 +34,7 @@ class ManageIQ::Providers::Autosde::StorageManager::EventCatcher::Runner < Manag
   def event_to_hash(event, ems_id)
     {
       :event_type               => event.event_type,
-      :source                   => "AUTOSDE",
+      :source                   => PhysicalStorage.find_by(:ems_ref=>event.storage_system).name,
       :ems_ref                  => event.event_id,
       :physical_storage_ems_ref => event.storage_system,
       :timestamp                => event.created_at,


### PR DESCRIPTION
This change will show on the event-monitor the source of  physical-storage as the name (instead the name of the provider), so when we open the event-monitor of Storage-Manager we can understand which physical-storage is reporting us.

# Before
![image](https://user-images.githubusercontent.com/6840118/185965898-9a80967f-df93-4f0c-b908-e32c5b997d93.png)

# After
![image](https://user-images.githubusercontent.com/6840118/185965130-9e4fe75f-4d7f-41ed-8d96-7ce6a4c29486.png)