### PR TITLE
populate `fixed` field in autosde events

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/event_catcher/runner.rb
@@ -31,16 +31,21 @@ class ManageIQ::Providers::Autosde::StorageManager::EventCatcher::Runner < Manag
 
   private
 
+  def prepend_fixed_status_to_event_type(event)
+    is_fixed = event.fixed == 'yes' ? 'fixed' : 'not fixed'
+    "#{is_fixed}: #{event.event_type}"
+  end
+
   def event_to_hash(event, ems_id)
     {
-      :event_type               => event.event_type,
+      :event_type               => prepend_fixed_status_to_event_type(event),
       :source                   => "AUTOSDE",
       :ems_ref                  => event.event_id,
       :physical_storage_ems_ref => event.storage_system,
       :timestamp                => event.created_at,
       :full_data                => event.to_hash,
       :ems_id                   => ems_id,
-      :message                  => event.description
+      :message                  => event.description,
     }
   end
 end


### PR DESCRIPTION
PR https://github.com/ManageIQ/manageiq-schema/pull/661 
is for adding a `fixed` field to `event_streams` model.
This PR is for populating this new field in autosde events