### PR TITLE
append event.fixed value to event.event_type

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/event_catcher/runner.rb
@@ -31,9 +31,13 @@ class ManageIQ::Providers::Autosde::StorageManager::EventCatcher::Runner < Manag
 
   private
 
+  def parse_event_type(event)
+    event.fixed == 'yes' ? "#{event.event_type}_fixed" : event.event_type
+  end
+
   def event_to_hash(event, ems_id)
     {
-      :event_type               => event.event_type,
+      :event_type               => parse_event_type(event),
       :source                   => "AUTOSDE",
       :ems_ref                  => event.event_id,
       :physical_storage_ems_ref => event.storage_system,


### PR DESCRIPTION
since there's no `fixed` field in `event_streams` model, we prepend the `fixed` value (passed from autosde) to `event_type` field