### PR TITLE
wait to refresh until status of job is success

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/autosde_client.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/autosde_client.rb
@@ -97,23 +97,14 @@ class ManageIQ::Providers::Autosde::StorageManager::AutosdeClient < AutosdeOpena
     end
   end
 
-  private_class_method def self.wait_for_success(ems, task_id, time_to_sleep = 1, wait_time = 60)
-    task_status = nil
-    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    while task_status != "SUCCESS" and task_status != "FAILURE" and Process.clock_gettime(Process::CLOCK_MONOTONIC) < start_time + wait_time
-      sleep(time_to_sleep)
-      task_status = ems.autosde_client.JobApi.jobs_pk_get(task_id).status
-    end
-    task_status
-  end
-
-  private_class_method def self.raise_non_success_exception(status)
-    if status == "FAILURE"
-      raise _("The Job failed")
-    elsif status == "PENDING" or status == "STARTED"
-      raise _("Timeout")
-    else
-      raise _("An unknown exception has occurred (Job status: '%{status_name}'") % {:status_name => status}
+  private_class_method def self.enqueue_refresh(target_class, target_id, ems_id, task_id)
+    ManageIQ::Providers::Autosde::StorageManager::EmsRefreshWorkflow.create_job(
+      :target_class   => target_class,
+      :target_id      => target_id,
+      :ems_id         => ems_id,
+      :native_task_id => task_id
+    ).tap do |job|
+      job.signal(:start)
     end
   end
 end

--- a/app/models/manageiq/providers/autosde/storage_manager/ems_refresh_workflow.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/ems_refresh_workflow.rb
@@ -1,0 +1,47 @@
+class ManageIQ::Providers::Autosde::StorageManager::EmsRefreshWorkflow < ManageIQ::Providers::EmsRefreshWorkflow
+
+  def run_native_op
+    queue_signal(:poll_native_task)
+  end
+  alias start run_native_op
+
+  def poll_native_task
+    case autosde_client.JobApi.jobs_pk_get(options[:native_task_id]).status
+    when "FAILURE"
+      signal(:abort, "Task failed")
+    when "SUCCESS"
+      queue_signal(:refresh)
+    else
+      queue_signal(:poll_native_task, :deliver_on => Time.now.utc + 1.minute)
+    end
+  rescue => err
+    _log.log_backtrace(err)
+    signal(:abort, err.message, "error")
+  end
+
+  def refresh
+    if options[:id] == nil
+      target = ext_management_system
+    else
+      target = target_entity
+    end
+    task_ids = EmsRefresh.queue_refresh_task(target)
+    if task_ids.blank?
+      process_error("Failed to queue refresh", "error")
+      queue_signal(:error)
+    else
+      context[:refresh_task_ids] = task_ids
+      update!(:context => context)
+
+      queue_signal(:poll_refresh)
+    end
+  end
+
+  def autosde_client
+    @autosde_client ||= ext_management_system.autosde_client
+  end
+
+  def ext_management_system
+    @ext_management_system ||= ExtManagementSystem.find(options[:ems_id])
+  end
+end

--- a/app/models/manageiq/providers/autosde/storage_manager/host_initiator.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/host_initiator.rb
@@ -27,7 +27,12 @@ class ManageIQ::Providers::Autosde::StorageManager::HostInitiator < ::HostInitia
 
   def raw_delete_host_initiator
     ems = ext_management_system
-    ems.autosde_client.StorageHostApi.storage_hosts_pk_delete(ems_ref)
-    EmsRefresh.queue_refresh(ems)
+    task_id = ems.autosde_client.StorageHostApi.storage_hosts_pk_delete(ems_ref)
+    status = ManageIQ::Providers::Autosde::StorageManager::AutosdeClient.wait_for_success(ems, task_id.task_id, 2, 4)
+    if status == "SUCCESS"
+      EmsRefresh.queue_refresh(ems)
+    else
+      ManageIQ::Providers::Autosde::StorageManager::AutosdeClient.raise_non_success_exception(done_status)
+    end
   end
 end

--- a/app/models/manageiq/providers/autosde/storage_manager/host_initiator.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/host_initiator.rb
@@ -26,13 +26,7 @@ class ManageIQ::Providers::Autosde::StorageManager::HostInitiator < ::HostInitia
   end
 
   def raw_delete_host_initiator
-    ems = ext_management_system
-    task_id = ems.autosde_client.StorageHostApi.storage_hosts_pk_delete(ems_ref)
-    status = ManageIQ::Providers::Autosde::StorageManager::AutosdeClient.wait_for_success(ems, task_id.task_id, 2, 4)
-    if status == "SUCCESS"
-      EmsRefresh.queue_refresh(ems)
-    else
-      ManageIQ::Providers::Autosde::StorageManager::AutosdeClient.raise_non_success_exception(done_status)
-    end
+    task_id = ext_management_system.autosde_client.StorageHostApi.storage_hosts_pk_delete(ems_ref).task_id
+    ext_management_system.class::AutosdeClient.enqueue_refresh(self.class.name, nil, ext_management_system.id, task_id)
   end
 end

--- a/app/models/manageiq/providers/autosde/storage_manager/volume_mapping.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/volume_mapping.rb
@@ -9,14 +9,9 @@ class ManageIQ::Providers::Autosde::StorageManager::VolumeMapping < ::VolumeMapp
   end
 
   def raw_delete_volume_mapping
-    ems = ext_management_system
-    task_id = ems.autosde_client.StorageHostsMappingApi.storage_hosts_mapping_pk_delete(ems_ref)
-    status = ManageIQ::Providers::Autosde::StorageManager::AutosdeClient.wait_for_success(ems, task_id.task_id, 2, 4)
-    if status == "SUCCESS"
-      EmsRefresh.queue_refresh(ext_management_system)
-    else
-      ManageIQ::Providers::Autosde::StorageManager::AutosdeClient.raise_non_success_exception(done_status)
-    end
+    task_id =
+      ext_management_system.autosde_client.StorageHostsMappingApi.storage_hosts_mapping_pk_delete(ems_ref).task_id
+    ext_management_system.class::AutosdeClient.enqueue_refresh(self.class.name, nil, ext_management_system.id, task_id)
   end
 
   def self.raw_create_volume_mapping(ext_management_system, options = {})


### PR DESCRIPTION
Until some time ago, the deletion and update of volumes, hosts, storages (and more) were done sinchronously, and when the task finished a refresh was done.

Since the update and deletion of those started being done with Celery, the refresh is being done immediately after the enqueue of the task without waiting for the task to finish to refresh.

I changed this to wait until the task successes and only then do the refresh (and in case it doesn't succeed or that the time waiting is longer than X seconds, it doesn't refresh but instead it raises an exception.