### PR TITLE
add `autosde_critical_alert_fixed` to critical power event group

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,6 +6,7 @@
         :power:
           :critical:
             - autosde_critical_alert
+            - autosde_critical_alert_fixed
             - AUTOSDE_instance_power_on
             - AUTOSDE_instance_power_off
 :http_proxy:


### PR DESCRIPTION
In merged PR https://github.com/ManageIQ/manageiq-providers-autosde/pull/171 the value `fixed` was appended to `event_type` `autosde_critical_alert` for fixed events.
`autosde_critical_alert` is listed in `/manageiq-providers-autosde/config/settings.yml` as part of the event_group power>critical, so `autosde_critical_alert_fixed` was added there as well.

**before** 
fixed event “test2_fixed” is not listed as part of the critical event group and does not appear in timeline:
![Timelines for Storage Manager asde97](https://user-images.githubusercontent.com/106743023/187685732-e5887fca-255d-408f-a403-84c39ee3adca.png)

**after** 
“test2_fixed” is also listed as critical and appears in timeline:
![Timelines for Storage Manager asde97](https://user-images.githubusercontent.com/106743023/187685869-bc0314d7-6b32-4d38-bdd8-26ff12f5a3d4.png)
