### PR TITLE
add create to queue

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/autosde_client.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/autosde_client.rb
@@ -96,15 +96,4 @@ class ManageIQ::Providers::Autosde::StorageManager::AutosdeClient < AutosdeOpena
       # when set to nil, url refers to config.host, as it should be
     end
   end
-
-  private_class_method def self.enqueue_refresh(target_class, target_id, ems_id, task_id)
-    ManageIQ::Providers::Autosde::StorageManager::EmsRefreshWorkflow.create_job(
-      :target_class   => target_class,
-      :target_id      => target_id,
-      :ems_id         => ems_id,
-      :native_task_id => task_id
-    ).tap do |job|
-      job.signal(:start)
-    end
-  end
 end

--- a/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
@@ -16,23 +16,32 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
       :size    => options["size"],
       :count   => options["count"]
     )
+    task_id = ext_management_system.autosde_client.VolumeApi.volumes_post(vol_to_create).task_id
 
-    new_volume = ext_management_system.autosde_client.VolumeApi.volumes_post(vol_to_create)
-
-    EmsRefresh.queue_refresh(
-      InventoryRefresh::Target.new(
-        :manager     => ext_management_system,
-        :association => :cloud_volumes,
-        :manager_ref => {:ems_ref => new_volume.uuid}
-      )
-    )
+    options = {
+      :target_class   => :cloud_volumes,
+      :target_id      => nil,
+      :ems_id         => ext_management_system.id,
+      :native_task_id => task_id,
+      :interval       => 10.seconds,
+      :target_option  => "new"
+    }
+    ext_management_system.class::EmsRefreshWorkflow.create_job(options).tap { |job| job.signal(:start) }
   end
 
   # ================= delete  ================
 
   def raw_delete_volume
     task_id = ext_management_system.autosde_client.VolumeApi.volumes_pk_delete(ems_ref).task_id
-    ext_management_system.class::AutosdeClient.enqueue_refresh(self.class.name, id, ext_management_system.id, task_id)
+    options = {
+      :target_class   => self.class.name,
+      :target_id      => id,
+      :ems_id         => ext_management_system.id,
+      :native_task_id => task_id,
+      :interval       => 1.minute,
+      :target_option  => "existing"
+    }
+    ext_management_system.class::EmsRefreshWorkflow.create_job(options).tap { |job| job.signal(:start) }
   end
 
   # ================= edit  ================
@@ -43,7 +52,16 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
       :size => options[:size_GB]
     )
     task_id = ext_management_system.autosde_client.VolumeApi.volumes_pk_put(ems_ref, update_details).task_id
-    ext_management_system.class::AutosdeClient.enqueue_refresh(self.class.name, id, ext_management_system.id, task_id)
+
+    options = {
+      :target_class   => self.class.name,
+      :target_id      => id,
+      :ems_id         => ext_management_system.id,
+      :native_task_id => task_id,
+      :interval       => 10.seconds,
+      :target_option  => "existing"
+    }
+    ext_management_system.class::EmsRefreshWorkflow.create_job(options).tap { |job| job.signal(:start) }
   end
 
   # ================ safe-delete ================

--- a/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
@@ -10,7 +10,15 @@ class ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage < ::Physical
 
   def raw_delete_physical_storage
     task_id = ext_management_system.autosde_client.StorageSystemApi.storage_systems_pk_delete(ems_ref).task_id
-    ext_management_system.class::AutosdeClient.enqueue_refresh(self.class.name, id, ext_management_system.id, task_id)
+    options = {
+      :target_id      => id,
+      :target_class   => self.class.name,
+      :ems_id         => ext_management_system.id,
+      :native_task_id => task_id,
+      :interval       => 1.minute,
+      :target_option  => "existing"
+    }
+    ext_management_system.class::EmsRefreshWorkflow.create_job(options).tap { |job| job.signal(:start) }
   end
 
   def self.raw_validate_physical_storage(ext_management_system, options = {})
@@ -30,9 +38,17 @@ class ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage < ::Physical
       :user          => options['user'] || "",
       :management_ip => options['management_ip'] || ""
     )
-    task_id =
-      ext_management_system.autosde_client.StorageSystemApi.storage_systems_pk_put(ems_ref, update_details).task_id
-    ext_management_system.class::AutosdeClient.enqueue_refresh(self.class.name, id, ext_management_system.id, task_id)
+    task_id = ext_management_system.autosde_client.StorageSystemApi.storage_systems_pk_put(ems_ref, update_details).task_id
+
+    options = {
+      :target_class   => self.class.name,
+      :target_id      => id,
+      :ems_id         => ext_management_system.id,
+      :native_task_id => task_id,
+      :interval       => 10.seconds,
+      :target_option  => "existing"
+    }
+    ext_management_system.class::EmsRefreshWorkflow.create_job(options).tap { |job| job.signal(:start) }
   end
 
   def self.raw_create_physical_storage(ext_management_system, options = {})
@@ -45,15 +61,17 @@ class ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage < ::Physical
     )
 
     begin
-      new_storage = ext_management_system.autosde_client.StorageSystemApi.storage_systems_post(sys_to_create)
+      task_id = ext_management_system.autosde_client.StorageSystemApi.storage_systems_post(sys_to_create).task_id
     ensure
-      EmsRefresh.queue_refresh(
-        InventoryRefresh::Target.new(
-          :manager     => ext_management_system,
-          :association => :physical_storages,
-          :manager_ref => {:ems_ref => new_storage.uuid}
-        )
-      )
+      options = {
+        :target_class   => :physical_storages,
+        :target_id      => nil,
+        :ems_id         => ext_management_system.id,
+        :native_task_id => task_id,
+        :interval       => 10.seconds,
+        :target_option  => "new"
+      }
+      ext_management_system.class::EmsRefreshWorkflow.create_job(options).tap { |job| job.signal(:start) }
     end
   end
 end


### PR DESCRIPTION
When creating a volume or a storage system, we used to receive the object with its uuid and with it we refreshed. Then when we started with celery we were receiving an async object with a task_id, and we were not receiving the data of the object itself (which hasn't been created yet) and we had no way to find out about it.

Now the new feature in autosde saves the object_id reference in the task itself.

So now we can use the state machine of refresh to wait until the task is in SUCCESS state and then we do the refresh, like with delete and update.