### PR TITLE
Override where clause functions and added helpers dir

### DIFF
--- a/app/helpers/manipulation_helper.rb
+++ b/app/helpers/manipulation_helper.rb
@@ -1,14 +1,14 @@
 module ManipulationHelper
-  def manipulate_storage_systems(assoc, storage_systems=nil)
-    if storage_systems.instance_of? Array and storage_systems.length >=1
+  def manipulate_storage_systems(assoc, storage_systems = nil)
+    if storage_systems.instance_of?(Array) && storage_systems.length >= 1
       rec_cond = ""
       storage_systems.each do |i|
-        rec_cond = rec_cond + "#{events_table_name(assoc)}.physical_storage_id = #{i}"
-        unless i.equal?storage_systems.last
-          rec_cond = rec_cond + " or "
+        rec_cond << "#{events_table_name(assoc)}.physical_storage_id = #{i}"
+        unless i.equal?(storage_systems.last)
+          rec_cond << " or "
         end
       end
-      return rec_cond
+      rec_cond
     end
   end
 end

--- a/app/helpers/manipulation_helper.rb
+++ b/app/helpers/manipulation_helper.rb
@@ -1,0 +1,14 @@
+module ManipulationHelper
+  def manipulate_storage_systems(assoc, storage_systems=nil)
+    if storage_systems.instance_of? Array and storage_systems.length >=1
+      rec_cond = ""
+      storage_systems.each do |i|
+        rec_cond = rec_cond + "#{events_table_name(assoc)}.physical_storage_id = #{i}"
+        unless i.equal?storage_systems.last
+          rec_cond = rec_cond + " or "
+        end
+      end
+      return rec_cond
+    end
+  end
+end

--- a/app/helpers/manipulation_helper.rb
+++ b/app/helpers/manipulation_helper.rb
@@ -1,14 +1,9 @@
 module ManipulationHelper
-  def manipulate_storage_systems(assoc, storage_systems = nil)
+  def storage_system_where_clause(assoc, storage_systems = nil)
     if storage_systems.instance_of?(Array) && storage_systems.length >= 1
-      rec_cond = ""
-      storage_systems.each do |i|
-        rec_cond << "#{events_table_name(assoc)}.physical_storage_id = #{i}"
-        unless i.equal?(storage_systems.last)
-          rec_cond << " or "
-        end
-      end
-      rec_cond
+      storage_systems.map do |i|
+        "#{events_table_name(assoc)}.physical_storage_id = #{i}"
+      end.join(" OR ")
     end
   end
 end

--- a/app/models/manageiq/providers/autosde/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager.rb
@@ -116,7 +116,7 @@ class ManageIQ::Providers::Autosde::StorageManager < ManageIQ::Providers::Storag
 
   def event_where_clause(assoc = :ems_events, storage_systems = nil)
     if storage_systems && storage_systems != ['']
-      return manipulate_storage_systems(assoc, storage_systems)
+      return storage_system_where_clause(assoc, storage_systems)
     end
 
     ["#{events_table_name(assoc)}.ems_id = ?", id]

--- a/app/models/manageiq/providers/autosde/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager.rb
@@ -115,14 +115,12 @@ class ManageIQ::Providers::Autosde::StorageManager < ManageIQ::Providers::Storag
   end
 
   def event_where_clause(assoc = :ems_events, storage_systems = nil)
-    if storage_systems and storage_systems != ['']
+    if storage_systems && storage_systems != ['']
       return manipulate_storage_systems(assoc, storage_systems)
     end
 
     ["#{events_table_name(assoc)}.ems_id = ?", id]
   end
-
-
 
   def assign_resources_info
     {

--- a/app/models/manageiq/providers/autosde/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager.rb
@@ -22,12 +22,12 @@ class ManageIQ::Providers::Autosde::StorageManager < ManageIQ::Providers::Storag
   supports :cloud_volume
   supports :catalog
 
-
   supports :add_storage
   supports :add_host_initiator
   supports :add_volume_mapping
 
   include ManageIQ::Providers::StorageManager::BlockMixin
+  include ManipulationHelper
 
   # Asset details
   has_many :physical_server_details,  :through => :physical_servers,  :source => :asset_detail
@@ -113,6 +113,16 @@ class ManageIQ::Providers::Autosde::StorageManager < ManageIQ::Providers::Storag
       count += physical_storages.count
     end
   end
+
+  def event_where_clause(assoc = :ems_events, storage_systems = nil)
+    if storage_systems and storage_systems != ['']
+      return manipulate_storage_systems(assoc, storage_systems)
+    end
+
+    ["#{events_table_name(assoc)}.ems_id = ?", id]
+  end
+
+
 
   def assign_resources_info
     {

--- a/app/models/manageiq/providers/autosde/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager.rb
@@ -115,7 +115,7 @@ class ManageIQ::Providers::Autosde::StorageManager < ManageIQ::Providers::Storag
   end
 
   def event_where_clause(assoc = :ems_events, storage_systems = nil)
-    if storage_systems && storage_systems != ['']
+    if storage_systems.present?
       return storage_system_where_clause(assoc, storage_systems)
     end
 

--- a/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
@@ -18,16 +18,15 @@ class ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage < ::Physical
   def event_where_clause(assoc = :ems_events, storage_systems = nil)
     case assoc.to_sym
     when :ems_events, :event_streams
-      if storage_systems and storage_systems != ['']
+      if storage_systems && storage_systems != ['']
         return manipulate_storage_systems(assoc, storage_systems)
       end
-      return ["#{events_table_name(assoc)}.physical_storage_id = ?", id]
+
+      ["#{events_table_name(assoc)}.physical_storage_id = ?", id]
     when :policy_events
-      return ["target_id = ? and target_class = ? ", id, self.class.base_class.name]
+      ["target_id = ? and target_class = ? ", id, self.class.base_class.name]
     end
   end
-
-
 
   def self.raw_validate_physical_storage(ext_management_system, options = {})
     validation_object = ext_management_system.autosde_client.StorageSystemCreate(

--- a/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
@@ -18,13 +18,13 @@ class ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage < ::Physical
   def event_where_clause(assoc = :ems_events, storage_systems = nil)
     case assoc.to_sym
     when :ems_events, :event_streams
-      if storage_systems && storage_systems != ['']
-        return manipulate_storage_systems(assoc, storage_systems)
+      if storage_systems.present?
+        return storage_system_where_clause(assoc, storage_systems)
       end
 
       ["#{events_table_name(assoc)}.physical_storage_id = ?", id]
     when :policy_events
-      ["target_id = ? and target_class = ? ", id, self.class.base_class.name]
+      ["target_id = ? AND target_class = ? ", id, self.class.base_class.name]
     end
   end
 


### PR DESCRIPTION
In order to filter events by the selected storage system, overriding the where_clause functions was needed.
Since both models share most of the query structuring code, I added a new 'helpers' directory and a helper function that both models use. 

This PR is related to another in UI repo:
https://github.com/ManageIQ/manageiq-ui-classic/pull/8424

Other helpers should be added to this directory