### PR TITLE
add provider events to Notifications

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/event_catcher/runner.rb
@@ -25,8 +25,19 @@ class ManageIQ::Providers::Autosde::StorageManager::EventCatcher::Runner < Manag
 
   def queue_event(event)
     _log.info("#{log_prefix} Caught event AutoSDE [#{event.event_id}]")
+    add_notification_type(event)
     event_hash = event_to_hash(event, @cfg[:ems_id])
     EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
+  end
+
+  def add_notification_type(event)
+    NotificationType.create_with(
+      :name       => event.event_type,
+      :level      => "warning",
+      :audience   => "global",
+      :expires_in => 7.days,
+      :message    => "%{event_type} in event %{uuid}, error code: %{error_code}. %{description}"
+    ).find_or_create_by(:name => event.event_type)
   end
 
   private

--- a/app/models/manageiq/providers/autosde/storage_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/event_catcher/runner.rb
@@ -25,19 +25,8 @@ class ManageIQ::Providers::Autosde::StorageManager::EventCatcher::Runner < Manag
 
   def queue_event(event)
     _log.info("#{log_prefix} Caught event AutoSDE [#{event.event_id}]")
-    add_notification_type(event)
     event_hash = event_to_hash(event, @cfg[:ems_id])
     EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
-  end
-
-  def add_notification_type(event)
-    NotificationType.create_with(
-      :name       => event.event_type,
-      :level      => "warning",
-      :audience   => "global",
-      :expires_in => 7.days,
-      :message    => "%{event_type} in event %{uuid}, error code: %{error_code}. %{description}"
-    ).find_or_create_by(:name => event.event_type)
   end
 
   private

--- a/content/notification_types.yml
+++ b/content/notification_types.yml
@@ -1,0 +1,6 @@
+---
+- :name: autosde_critical_alert
+  :message: '%{event_type} in event %{uuid}, error code: %{error_code}. %{description}'
+  :expires_in: 7.days
+  :level: :warning
+  :audience: global


### PR DESCRIPTION
We're receiving events from Autosde, which were only presented in the monitoring section.

Now, when polling the events, they're also being sent to Notifications, with a new notification type with the name of the type of the event.

<img width="459" alt="Screen Shot 2022-09-13 at 13 22 31" src="https://user-images.githubusercontent.com/50288766/189877675-72909b45-2741-44b4-85d3-f66cd2c3ab9a.png">
