### PR TITLE
add refresh after creating manager

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager.rb
@@ -184,6 +184,7 @@ class ManageIQ::Providers::Autosde::StorageManager < ManageIQ::Providers::Storag
     host       = options[:host] || address
     port       = options[:port] || self.port
     self.class.raw_connect(username, password, host, port).login
+    EmsRefresh.queue_refresh(ext_management_system)
   end
 
   def self.validate_authentication_args(params)


### PR DESCRIPTION
Until now, when adding a storage manager sometimes it took a long time until an automatic refresh happened, and this caused that the user wasn't able to add the type system of a new physical storage until a manual refresh.

<img width="499" alt="MicrosoftTeams-image (1)" src="https://user-images.githubusercontent.com/50288766/191690587-f6a35b08-8a22-4c1b-99f1-b83c9d9afa3c.png">

So a refresh was added directly after connecting to the storage manager.

<img width="620" alt="Screen Shot 2022-09-22 at 10 55 14" src="https://user-images.githubusercontent.com/50288766/191690895-bf59e74f-de40-4dce-99f9-dd066b6038f2.png">

