### PR TITLE
auto selected wwpn passed as empty str on host initiator creation 

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/host_initiator.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/host_initiator.rb
@@ -5,7 +5,7 @@ class ManageIQ::Providers::Autosde::StorageManager::HostInitiator < ::HostInitia
   def self.raw_create_host_initiator(ext_management_system, options = {})
     # WWPN/IQN values sent to autosde should be format as colon separated string (e.g. WWPN1:WWPN2:WWPN3)
     wwpns = Array(options['custom_wwpn'])
-    wwpns += Array(options['wwpn']).map { |item| item["value"] }
+    wwpns += Array(options['wwpn'])
     wwpn_values = wwpns.join(":")
 
     iqns = Array(options['iqn'])


### PR DESCRIPTION
host initiator wwpn field used to be passed as a complex value - a hash with the keys of value and label.

after PR 8349 https://github.com/ManageIQ/manageiq-ui-classic/pull/8349 it is now passed as a simpleValue str, 
but host_initiator.rb wasn't adjusted to that, so it still tried to unpack it as a hash, which caused an empty str to be sent to the api.

removing the call to .map() fixed the issue