### PR TITLE
return error when there is no 'response_body'

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/autosde_client.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/autosde_client.rb
@@ -70,8 +70,12 @@ class ManageIQ::Providers::Autosde::StorageManager::AutosdeClient < AutosdeOpena
     data = self.AuthenticationApi.token_auth_post(auth_request, opts)
     @token = data.token
   rescue AutosdeOpenapiClient::ApiError => e
-    error_data = JSON.parse(e.response_body)
-    raise AUTH_ERRR_MSG + error_data.dig("detail", "non_field_errors")&.first
+    error_data = if e.response_body
+                   JSON.parse(e.response_body).dig("detail", "non_field_errors")&.first
+                 else
+                   e
+                 end
+    raise "#{AUTH_ERRR_MSG}: #{error_data}"
   rescue => e
     raise AUTH_ERRR_MSG + e.to_s
   end


### PR DESCRIPTION
When trying to add a storage from a wrong IP, we get the following response to the UI:

<img width="570" alt="9ad9dad8-178b-4316-9bc5-2a9d011af179" src="https://user-images.githubusercontent.com/50288766/201641365-e1ef91ab-79c7-4d5c-b744-e33883518ef7.png">

Now it will receive the original error of the response of the HTTP request:

<img width="636" alt="Screen Shot 2022-11-14 at 12 51 55" src="https://user-images.githubusercontent.com/50288766/201642153-b2c19b67-23e3-435c-9738-39d771e8c13f.png">
