### PR TITLE
check for autosde refresh status after creating storage system

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
@@ -15,7 +15,7 @@ class ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage < ::Physical
       :target_class   => self.class.name,
       :ems_id         => ext_management_system.id,
       :native_task_id => task_id,
-      :interval       => 1.minute,
+      :interval       => 30.seconds,
       :target_option  => "existing"
     }
     ext_management_system.class::EmsRefreshWorkflow.create_job(options).tap(&:signal_start)


### PR DESCRIPTION
After adding a storage system, the refresh workflow takes care of refreshing after autosde's task of adding the storage system gets to success state. That's also the case for creating / updating / deleting volumes / hosts / mappings

But the problem is that, after adding a storage system, autosde shoots another asynchronous task of refreshing itself (which brings resources from the actual storage). And we want to refresh miq only after that task is completed, so it also refreshes pools, volumes and hosts, and so it doesn't look like this:

<img width="1243" alt="cf42aa6f-1d1b-4ba5-99d2-68196358b09c" src="https://user-images.githubusercontent.com/50288766/204808109-8fe6881c-6f35-4e83-b976-663531cbeccd.png">

So I added some data to the refresh tasks to be able to locate the task, and updated the refresh workflow with a second poll task for this specific case.

I could have done it in the same poll_native_task, but in that case I would have to asked conditions at the beginning of it for every refresh task called, which seems to me wasteful. So I did it in a second function (and that's why I overrode the load_transtions, in order to add the transition for that new function). 