### PR TITLE
add ems_refresh_workflow to host group and updated times to wait

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
@@ -38,7 +38,7 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
       :target_id      => id,
       :ems_id         => ext_management_system.id,
       :native_task_id => task_id,
-      :interval       => 1.minute,
+      :interval       => 20.seconds,
       :target_option  => "existing"
     }
     ext_management_system.class::EmsRefreshWorkflow.create_job(options).tap(&:signal_start)

--- a/app/models/manageiq/providers/autosde/storage_manager/host_initiator.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/host_initiator.rb
@@ -44,7 +44,7 @@ class ManageIQ::Providers::Autosde::StorageManager::HostInitiator < ::HostInitia
       :target_id      => nil,
       :ems_id         => ext_management_system.id,
       :native_task_id => task_id,
-      :interval       => 1.minute,
+      :interval       => 20.seconds,
       :target_option  => "ems"
     }
     ext_management_system.class::EmsRefreshWorkflow.create_job(options).tap(&:signal_start)

--- a/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
@@ -15,7 +15,7 @@ class ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage < ::Physical
       :target_class   => self.class.name,
       :ems_id         => ext_management_system.id,
       :native_task_id => task_id,
-      :interval       => 30.seconds,
+      :interval       => 20.seconds,
       :target_option  => "existing"
     }
     ext_management_system.class::EmsRefreshWorkflow.create_job(options).tap(&:signal_start)

--- a/app/models/manageiq/providers/autosde/storage_manager/volume_mapping.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/volume_mapping.rb
@@ -16,7 +16,7 @@ class ManageIQ::Providers::Autosde::StorageManager::VolumeMapping < ::VolumeMapp
       :target_id      => nil,
       :ems_id         => ext_management_system.id,
       :native_task_id => task_id,
-      :interval       => 1.minute,
+      :interval       => 20.seconds,
       :target_option  => "ems"
     }
     ext_management_system.class::EmsRefreshWorkflow.create_job(options).tap(&:signal_start)


### PR DESCRIPTION
The same way we're refreshing after all create / update / delete in volumes / hosts / physical storage, through the ems_refresh_workflow (which refreshes only after their tasks gets to success state), we're doing now for host initiator groups.

<img width="491" alt="Screen Shot 2022-12-13 at 17 46 25" src="https://user-images.githubusercontent.com/50288766/207379214-20dd4e18-721f-42f3-aaca-17df00c86a37.png">

Besides, I reduced the amount of time to wait be
tween attempts of refreshing for other tasks, since we've reduced the time needed for those operations (and it will help us reduce time of testing with testcafe).