### PR TITLE
storage manager volume create: basic and advanced modes

### DIFF
--- a/app/models/manageiq/providers/autosde/inventory/collector/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/inventory/collector/storage_manager.rb
@@ -42,4 +42,8 @@ class ManageIQ::Providers::Autosde::Inventory::Collector::StorageManager < Manag
   def host_initiator_groups
     @host_initiator_groups ||= @manager.autosde_client.HostClusterApi.host_clusters_get
   end
+
+  def capability_values
+    @capability_values ||= @manager.autosde_client.ServiceAbstractCapabilityValueApi.service_abstract_capability_values_get
+  end
 end

--- a/app/models/manageiq/providers/autosde/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/autosde/inventory/collector/target_collection.rb
@@ -56,6 +56,10 @@ class ManageIQ::Providers::Autosde::Inventory::Collector::TargetCollection < Man
     []
   end
 
+  def capability_values
+    []
+  end
+
   private
 
   def parse_targets!

--- a/app/models/manageiq/providers/autosde/inventory/parser/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/inventory/parser/storage_manager.rb
@@ -11,6 +11,7 @@ class ManageIQ::Providers::Autosde::Inventory::Parser::StorageManager < ManageIQ
   #     :ems_ref => "s2", :name => "Storage 3", :ems_id=>persister.manager.id
   # )#
   def parse
+    ext_management_system
     physical_storage_families
     physical_storages
     storage_resources
@@ -21,6 +22,13 @@ class ManageIQ::Providers::Autosde::Inventory::Parser::StorageManager < ManageIQ
     cloud_volumes
     volume_mappings
     wwpn_candidates
+  end
+
+  def ext_management_system
+    persister.ext_management_system.build(
+      :guid         => persister.manager.guid,
+      :capabilities => collector.capability_values
+    )
   end
 
   def physical_storage_families
@@ -116,10 +124,11 @@ class ManageIQ::Providers::Autosde::Inventory::Parser::StorageManager < ManageIQ
   def storage_services
     collector.storage_services.each do |service|
       persister.storage_services.build(
-        :name        => service.name,
-        :description => service.description,
-        :version     => service.version,
-        :ems_ref     => service.uuid
+        :name         => service.name,
+        :description  => service.description,
+        :version      => service.version,
+        :ems_ref      => service.uuid,
+        :capabilities => parse_capabilities(service.capability_values_json)
       )
     end
   end

--- a/app/models/manageiq/providers/autosde/inventory/persister/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/inventory/persister/storage_manager.rb
@@ -16,5 +16,6 @@ class ManageIQ::Providers::Autosde::Inventory::Persister::StorageManager < Manag
     add_collection(storage, :storage_resources)
     add_collection(storage, :storage_services)
     add_collection(storage, :cloud_volumes)
+    add_collection(storage, :ext_management_system)
   end
 end

--- a/spec/models/manageiq/providers/autosde/storage_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/autosde/storage_manager/refresher_spec.rb
@@ -212,7 +212,7 @@ describe ManageIQ::Providers::Autosde::StorageManager::Refresher do
     def assert_ems
       expect(ems.physical_storages.count).to(eq(1))
       expect(ems.physical_storage_families.count).to(eq(2))
-      expect(ems.storage_resources.count).to(eq(8))
+      expect(ems.storage_resources.count).to(eq(9))
       expect(ems.storage_services.count).to(eq(7))
       expect(ems.cloud_volumes.count).to(eq(13))
       expect(ems.wwpn_candidates.count).to(eq(2))
@@ -251,15 +251,15 @@ describe ManageIQ::Providers::Autosde::StorageManager::Refresher do
     end
 
     def assert_specific_storage_resource
-      storage_resource = ems.storage_resources.find_by(:ems_ref => "e6833c27-374b-4a4a-8d76-455cfe5f4270")
+      storage_resource = ems.storage_resources.find_by(:ems_ref => "41e4e6fb-d670-4db9-8325-464c138dee6f")
       expect(storage_resource).to(have_attributes(
-                                    :name             => "9.151.159.178:ilyak_test_pool",
-                                    :ems_ref          => "e6833c27-374b-4a4a-8d76-455cfe5f4270",
-                                    :logical_free     => 601_295_421_440,
-                                    :logical_total    => 0,
-                                    :physical_storage => ems.physical_storages.find_by(:ems_ref => "980f3ceb-c599-49c4-9db3-fdc793cb8666"),
+                                    :name             => "test_or_30:test_pool",
+                                    :ems_ref          => "41e4e6fb-d670-4db9-8325-464c138dee6f",
+                                    :logical_free     => 472_446_402_560,
+                                    :logical_total    => 515_396_075_520,
+                                    :physical_storage => ems.physical_storages.find_by(:ems_ref => "9b1cedc0-b476-47f1-8f25-7a7da2b7d91c"),
                                     :type             => "ManageIQ::Providers::Autosde::StorageManager::StorageResource",
-                                    :capabilities     => [{"name" => "compression", "uuid" => "29ac2ba7-1e55-411e-9828-472c935bb882", "value" => "True"}, {"name" => "thin_provision", "uuid" => "63a2dfbe-bb1b-408c-8e94-36c9d7791df2", "value" => "True"}]
+                                    :capabilities     => [{"name" => "compression", "uuid" => "45e0cf41-1842-45e8-b83b-17de54be406d", "value" => "True"}, {"name" => "thin_provision", "uuid" => "2fddfc81-2561-40d8-bd84-cec6ec26d551", "value" => "True"}]
                                   ))
     end
 

--- a/spec/vcr_cassettes/ems_refresh_v1.yml
+++ b/spec/vcr_cassettes/ems_refresh_v1.yml
@@ -175,7 +175,7 @@ http_interactions:
       - GET, POST, OPTIONS, PUT, DELETE
     body:
       encoding: ASCII-8BIT
-      string: '[{"advanced_attributes_map":"{}","component_state":"PENDING_CREATION","logical_free":601295421440,"logical_total":0,"name":"9.151.159.178:ilyak_test_pool","pool_name":"ilyak_test_pool","protocol":"fc","storage_system":"980f3ceb-c599-49c4-9db3-fdc793cb8666","uuid":"e6833c27-374b-4a4a-8d76-455cfe5f4270","capability_values_json":"[{\"abstract_capability\": \"compression\", \"value\": \"True\", \"uuid\": \"29ac2ba7-1e55-411e-9828-472c935bb882\"}, {\"abstract_capability\": \"thin_provision\", \"value\": \"True\", \"uuid\": \"63a2dfbe-bb1b-408c-8e94-36c9d7791df2\"}]","replication_target_resource":null},{"advanced_attributes_map":"{}","component_state":"PENDING_CREATION","logical_free":600221679616,"logical_total":0,"name":"9.151.159.178:liranl_test_pool","pool_name":"liranl_test_pool","protocol":"fc","storage_system":"980f3ceb-c599-49c4-9db3-fdc793cb8666","uuid":"990449ba-614e-4b10-82d7-e1b41280309d","capability_values_json":"[{\"abstract_capability\": \"compression\", \"value\": \"True\", \"uuid\": \"29ac2ba7-1e55-411e-9828-472c935bb882\"}, {\"abstract_capability\": \"thin_provision\", \"value\": \"True\", \"uuid\": \"63a2dfbe-bb1b-408c-8e94-36c9d7791df2\"}]","replication_target_resource":null},{"advanced_attributes_map":"{}","component_state":"PENDING_CREATION","logical_free":601295421440,"logical_total":0,"name":"9.151.159.178:demo_test_pool","pool_name":"demo_test_pool","protocol":"fc","storage_system":"980f3ceb-c599-49c4-9db3-fdc793cb8666","uuid":"ef48e37b-5b49-4af7-a284-ea40d470b402","capability_values_json":"[{\"abstract_capability\": \"compression\", \"value\": \"True\", \"uuid\": \"29ac2ba7-1e55-411e-9828-472c935bb882\"}, {\"abstract_capability\": \"thin_provision\", \"value\": \"True\", \"uuid\": \"63a2dfbe-bb1b-408c-8e94-36c9d7791df2\"}]","replication_target_resource":null},{"advanced_attributes_map":"{}","component_state":"PENDING_CREATION","logical_free":601295421440,"logical_total":0,"name":"9.151.159.178:lohit_test_pool","pool_name":"lohit_test_pool","protocol":"fc","storage_system":"980f3ceb-c599-49c4-9db3-fdc793cb8666","uuid":"1cf5bc7a-3809-401d-92bd-cab7806616c8","capability_values_json":"[{\"abstract_capability\": \"compression\", \"value\": \"True\", \"uuid\": \"29ac2ba7-1e55-411e-9828-472c935bb882\"}, {\"abstract_capability\": \"thin_provision\", \"value\": \"True\", \"uuid\": \"63a2dfbe-bb1b-408c-8e94-36c9d7791df2\"}]","replication_target_resource":null},{"advanced_attributes_map":"{}","component_state":"PENDING_CREATION","logical_free":598074195968,"logical_total":0,"name":"9.151.159.178:felixnu_test_pool","pool_name":"felixnu_test_pool","protocol":"fc","storage_system":"980f3ceb-c599-49c4-9db3-fdc793cb8666","uuid":"d40d2c7c-99d9-4971-98b2-2c9f1b8199c0","capability_values_json":"[{\"abstract_capability\": \"compression\", \"value\": \"True\", \"uuid\": \"29ac2ba7-1e55-411e-9828-472c935bb882\"}, {\"abstract_capability\": \"thin_provision\", \"value\": \"True\", \"uuid\": \"63a2dfbe-bb1b-408c-8e94-36c9d7791df2\"}]","replication_target_resource":null},{"advanced_attributes_map":"{}","component_state":"PENDING_CREATION","logical_free":585189294080,"logical_total":600221679616,"name":"9.151.159.178:borisko_test_pool","pool_name":"borisko_test_pool","protocol":"fc","storage_system":"980f3ceb-c599-49c4-9db3-fdc793cb8666","uuid":"0a10636f-c204-4ae1-a370-f0ee850b80af","capability_values_json":"[{\"abstract_capability\": \"compression\", \"value\": \"True\", \"uuid\": \"29ac2ba7-1e55-411e-9828-472c935bb882\"}, {\"abstract_capability\": \"thin_provision\", \"value\": \"True\", \"uuid\": \"63a2dfbe-bb1b-408c-8e94-36c9d7791df2\"}]","replication_target_resource":null},{"advanced_attributes_map":"{}","component_state":"PENDING_CREATION","logical_free":600221679616,"logical_total":0,"name":"9.151.159.178:erezt_test_pool","pool_name":"erezt_test_pool","protocol":"fc","storage_system":"980f3ceb-c599-49c4-9db3-fdc793cb8666","uuid":"2d685f09-7a11-427d-8bb3-539f3286496b","capability_values_json":"[{\"abstract_capability\": \"compression\", \"value\": \"True\", \"uuid\": \"29ac2ba7-1e55-411e-9828-472c935bb882\"}, {\"abstract_capability\": \"thin_provision\", \"value\": \"True\", \"uuid\": \"63a2dfbe-bb1b-408c-8e94-36c9d7791df2\"}]","replication_target_resource":null},{"advanced_attributes_map":"{}","component_state":"PENDING_CREATION","logical_free":595926712320,"logical_total":0,"name":"9.151.159.178:gregoryb_test_pool","pool_name":"gregoryb_test_pool","protocol":"fc","storage_system":"980f3ceb-c599-49c4-9db3-fdc793cb8666","uuid":"b35f4df5-d59c-4b59-8ccd-7ddcf2901c00","capability_values_json":"[{\"abstract_capability\": \"compression\", \"value\": \"True\", \"uuid\": \"29ac2ba7-1e55-411e-9828-472c935bb882\"}, {\"abstract_capability\": \"thin_provision\", \"value\": \"True\", \"uuid\": \"63a2dfbe-bb1b-408c-8e94-36c9d7791df2\"}]","replication_target_resource":null}]'
+      string: '[{"advanced_attributes_map":"{}","capability_values_json":"[{\"abstract_capability\": \"compression\", \"value\": \"True\", \"uuid\": \"45e0cf41-1842-45e8-b83b-17de54be406d\"}, {\"abstract_capability\": \"thin_provision\", \"value\": \"True\", \"uuid\": \"2fddfc81-2561-40d8-bd84-cec6ec26d551\"}]","component_state":"PENDING_CREATION","logical_free":513248591872,"logical_total":515396075520,"name":"test_or_30:Pool5","pool_name":"Pool5","protocol":"fc","storage_system":"9b1cedc0-b476-47f1-8f25-7a7da2b7d91c","uuid":"ecd03d66-1c83-466c-9b86-ff63483cd0da","replication_target_resource":null},{"advanced_attributes_map":"{}","capability_values_json":"[{\"abstract_capability\": \"compression\", \"value\": \"True\", \"uuid\": \"45e0cf41-1842-45e8-b83b-17de54be406d\"}, {\"abstract_capability\": \"thin_provision\", \"value\": \"True\", \"uuid\": \"2fddfc81-2561-40d8-bd84-cec6ec26d551\"}]","component_state":"PENDING_CREATION","logical_free":508232204288,"logical_total":515949723648,"name":"test_or_30:updateOr2","pool_name":"updateOr2","protocol":"fc","storage_system":"9b1cedc0-b476-47f1-8f25-7a7da2b7d91c","uuid":"dd3aa3ed-b898-47a4-a272-de3244f1372a","replication_target_resource":null},{"advanced_attributes_map":"{}","capability_values_json":"[{\"abstract_capability\": \"compression\", \"value\": \"True\", \"uuid\": \"45e0cf41-1842-45e8-b83b-17de54be406d\"}, {\"abstract_capability\": \"thin_provision\", \"value\": \"True\", \"uuid\": \"2fddfc81-2561-40d8-bd84-cec6ec26d551\"}]","component_state":"PENDING_CREATION","logical_free":507879882752,"logical_total":514322333696,"name":"test_or_30:tony_pool","pool_name":"tony_pool","protocol":"fc","storage_system":"9b1cedc0-b476-47f1-8f25-7a7da2b7d91c","uuid":"4cc7fa4e-fa05-47fb-8269-869942e11f86","replication_target_resource":null},{"advanced_attributes_map":"{}","capability_values_json":"[{\"abstract_capability\": \"compression\", \"value\": \"True\", \"uuid\": \"45e0cf41-1842-45e8-b83b-17de54be406d\"}, {\"abstract_capability\": \"thin_provision\", \"value\": \"True\", \"uuid\": \"2fddfc81-2561-40d8-bd84-cec6ec26d551\"}]","component_state":"PENDING_CREATION","logical_free":472446402560,"logical_total":515396075520,"name":"test_or_30:test_pool","pool_name":"test_pool","protocol":"fc","storage_system":"9b1cedc0-b476-47f1-8f25-7a7da2b7d91c","uuid":"41e4e6fb-d670-4db9-8325-464c138dee6f","replication_target_resource":null},{"advanced_attributes_map":"{}","capability_values_json":"[{\"abstract_capability\": \"compression\", \"value\": \"True\", \"uuid\": \"45e0cf41-1842-45e8-b83b-17de54be406d\"}, {\"abstract_capability\": \"thin_provision\", \"value\": \"True\", \"uuid\": \"2fddfc81-2561-40d8-bd84-cec6ec26d551\"}]","component_state":"PENDING_CREATION","logical_free":507879882752,"logical_total":514322333696,"name":"test_or_30:Pool0","pool_name":"Pool0","protocol":"fc","storage_system":"9b1cedc0-b476-47f1-8f25-7a7da2b7d91c","uuid":"4d2eaeaf-0207-4418-bac3-bdae9a4115cc","replication_target_resource":null},{"advanced_attributes_map":"{}","capability_values_json":"[{\"abstract_capability\": \"compression\", \"value\": \"True\", \"uuid\": \"45e0cf41-1842-45e8-b83b-17de54be406d\"}, {\"abstract_capability\": \"thin_provision\", \"value\": \"True\", \"uuid\": \"2fddfc81-2561-40d8-bd84-cec6ec26d551\"}]","component_state":"PENDING_CREATION","logical_free":514322333696,"logical_total":515396075520,"name":"test_or_30:Pool1","pool_name":"Pool1","protocol":"fc","storage_system":"9b1cedc0-b476-47f1-8f25-7a7da2b7d91c","uuid":"03516eb2-d2d9-40c7-921c-6dcf9a835775","replication_target_resource":null},{"advanced_attributes_map":"{}","capability_values_json":"[{\"abstract_capability\": \"compression\", \"value\": \"True\", \"uuid\": \"45e0cf41-1842-45e8-b83b-17de54be406d\"}, {\"abstract_capability\": \"thin_provision\", \"value\": \"True\", \"uuid\": \"2fddfc81-2561-40d8-bd84-cec6ec26d551\"}]","component_state":"PENDING_CREATION","logical_free":515396075520,"logical_total":515396075520,"name":"test_or_30:Pool2","pool_name":"Pool2","protocol":"fc","storage_system":"9b1cedc0-b476-47f1-8f25-7a7da2b7d91c","uuid":"9dbda310-d848-439b-a337-39236b225057","replication_target_resource":null},{"advanced_attributes_map":"{}","capability_values_json":"[{\"abstract_capability\": \"compression\", \"value\": \"True\", \"uuid\": \"45e0cf41-1842-45e8-b83b-17de54be406d\"}, {\"abstract_capability\": \"thin_provision\", \"value\": \"True\", \"uuid\": \"2fddfc81-2561-40d8-bd84-cec6ec26d551\"}]","component_state":"PENDING_CREATION","logical_free":515396075520,"logical_total":515396075520,"name":"test_or_30:Pool3","pool_name":"Pool3","protocol":"fc","storage_system":"9b1cedc0-b476-47f1-8f25-7a7da2b7d91c","uuid":"53cca325-a529-4a97-a756-e86c3342ce9e","replication_target_resource":null},{"advanced_attributes_map":"{}","capability_values_json":"[{\"abstract_capability\": \"compression\", \"value\": \"True\", \"uuid\": \"45e0cf41-1842-45e8-b83b-17de54be406d\"}, {\"abstract_capability\": \"thin_provision\", \"value\": \"True\", \"uuid\": \"2fddfc81-2561-40d8-bd84-cec6ec26d551\"}]","component_state":"PENDING_CREATION","logical_free":515396075520,"logical_total":515396075520,"name":"test_or_30:Pool4","pool_name":"Pool4","protocol":"fc","storage_system":"9b1cedc0-b476-47f1-8f25-7a7da2b7d91c","uuid":"38575e25-8bc6-4e2a-b2c4-bcb2e6c7683f","replication_target_resource":null}]'
     http_version: null
   recorded_at: Mon, 25 Oct 2021 09:51:29 GMT
 - request:
@@ -492,6 +492,51 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '[{"wwpn":"2100000E1EE89D90","system_uuid":"a785c49a-2f3c-4e6d-8ace-879dfa1719a2"},
       {"wwpn":"2100000E1EE89D91","system_uuid":"a785c49a-2f3c-4e6d-8ace-879dfa1719a2"}]'
+    http_version: null
+  recorded_at: Mon, 25 Oct 2021 09:51:49 GMT
+- request:
+    method: get
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/service-abstract-capability-values
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+        - OpenAPI-Generator/1.0.2/ruby
+      Content-Type:
+        - application/json
+      Accept:
+        - "*/*"
+      Authorization:
+        - Bearer fdf68692f2a4c981b946a651363d96cddd711999
+      Expect:
+        - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+        - Mon, 25 Oct 2021 09:51:49 GMT
+      Server:
+        - WSGIServer/0.2 CPython/3.7.3
+      Content-Type:
+        - application/json
+      Vary:
+        - Accept
+      Allow:
+        - GET, HEAD, OPTIONS
+      X-Frame-Options:
+        - SAMEORIGIN
+      Access-Control-Allow-Origin:
+        - "*"
+      Access-Control-Allow-Headers:
+        - "*"
+      Access-Control-Allow-Methods:
+        - GET, POST, OPTIONS, PUT, DELETE
+    body:
+      encoding: ASCII-8BIT
+      string: '[]'
     http_version: null
   recorded_at: Mon, 25 Oct 2021 09:51:49 GMT
 recorded_with: VCR 5.1.0

--- a/spec/vcr_cassettes/ems_refresh_v2.yml
+++ b/spec/vcr_cassettes/ems_refresh_v2.yml
@@ -175,7 +175,7 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"count":8,"next":null,"previous":null,"results":[{"advanced_attributes_map":"{}","component_state":"PENDING_CREATION","logical_free":515396075520,"logical_total":515396075520,"name":"Barmetall9_SVC:Pool3","pool_name":"Pool3","protocol":"fc","storage_system":"78ef7ca4-2ce9-4983-aa49-76dbeedcbedf","uuid":"2423882a-c95b-4416-ac45-d379802eb451","abstract_capability_values":{},"replication_target_resource":null},{"advanced_attributes_map":"{}","component_state":"PENDING_CREATION","logical_free":515396075520,"logical_total":515396075520,"name":"Barmetall9_SVC:Pool4","pool_name":"Pool4","protocol":"fc","storage_system":"78ef7ca4-2ce9-4983-aa49-76dbeedcbedf","uuid":"c1c75b48-6bfb-49c5-9246-46f590469905","abstract_capability_values":{},"replication_target_resource":null},{"advanced_attributes_map":"{}","component_state":"PENDING_CREATION","logical_free":514322333696,"logical_total":515396075520,"name":"Barmetall9_SVC:Pool5","pool_name":"Pool5","protocol":"fc","storage_system":"78ef7ca4-2ce9-4983-aa49-76dbeedcbedf","uuid":"ce04c588-1cd8-40ce-8f67-06d51fb3548e","abstract_capability_values":{},"replication_target_resource":null},{"advanced_attributes_map":"{}","component_state":"PENDING_CREATION","logical_free":502662168576,"logical_total":515949723648,"name":"Barmetall9_SVC:test_pool","pool_name":"test_pool","protocol":"fc","storage_system":"78ef7ca4-2ce9-4983-aa49-76dbeedcbedf","uuid":"0be07c17-9775-422a-a03c-8fa158c5f297","abstract_capability_values":{},"replication_target_resource":null},{"advanced_attributes_map":"{}","component_state":"PENDING_CREATION","logical_free":506806140928,"logical_total":514322333696,"name":"Barmetall9_SVC:tony_pool","pool_name":"tony_pool","protocol":"fc","storage_system":"78ef7ca4-2ce9-4983-aa49-76dbeedcbedf","uuid":"38828f47-4ea6-4d9b-8188-d7a13101f78a","abstract_capability_values":{},"replication_target_resource":null},{"advanced_attributes_map":"{}","component_state":"PENDING_CREATION","logical_free":514322333696,"logical_total":514322333696,"name":"Barmetall9_SVC:Pool0","pool_name":"Pool0","protocol":"fc","storage_system":"78ef7ca4-2ce9-4983-aa49-76dbeedcbedf","uuid":"e9afbed2-697d-4c98-a900-80e6a7e356d1","abstract_capability_values":{},"replication_target_resource":null},{"advanced_attributes_map":"{}","component_state":"PENDING_CREATION","logical_free":515396075520,"logical_total":515396075520,"name":"Barmetall9_SVC:Pool1","pool_name":"Pool1","protocol":"fc","storage_system":"78ef7ca4-2ce9-4983-aa49-76dbeedcbedf","uuid":"adf19962-6bee-4a54-88bb-e569d0fb39a2","abstract_capability_values":{},"replication_target_resource":null},{"advanced_attributes_map":"{}","component_state":"PENDING_CREATION","logical_free":515396075520,"logical_total":515396075520,"name":"Barmetall9_SVC:Pool2","pool_name":"Pool2","protocol":"fc","storage_system":"78ef7ca4-2ce9-4983-aa49-76dbeedcbedf","uuid":"b18d8272-7e4f-4045-b702-a16dae5e31c1","abstract_capability_values":{},"replication_target_resource":null}]}'
+      string: '{"count":9,"next":null,"previous":null,"results":[{"advanced_attributes_map":"{}","capability_values_json":"[{\"abstract_capability\": \"compression\", \"value\": \"True\", \"uuid\": \"45e0cf41-1842-45e8-b83b-17de54be406d\"}, {\"abstract_capability\": \"thin_provision\", \"value\": \"True\", \"uuid\": \"2fddfc81-2561-40d8-bd84-cec6ec26d551\"}]","component_state":"PENDING_CREATION","logical_free":513248591872,"logical_total":515396075520,"name":"test_or_30:Pool5","pool_name":"Pool5","protocol":"fc","storage_system":"9b1cedc0-b476-47f1-8f25-7a7da2b7d91c","uuid":"ecd03d66-1c83-466c-9b86-ff63483cd0da","replication_target_resource":null},{"advanced_attributes_map":"{}","capability_values_json":"[{\"abstract_capability\": \"compression\", \"value\": \"True\", \"uuid\": \"45e0cf41-1842-45e8-b83b-17de54be406d\"}, {\"abstract_capability\": \"thin_provision\", \"value\": \"True\", \"uuid\": \"2fddfc81-2561-40d8-bd84-cec6ec26d551\"}]","component_state":"PENDING_CREATION","logical_free":508232204288,"logical_total":515949723648,"name":"test_or_30:updateOr2","pool_name":"updateOr2","protocol":"fc","storage_system":"9b1cedc0-b476-47f1-8f25-7a7da2b7d91c","uuid":"dd3aa3ed-b898-47a4-a272-de3244f1372a","replication_target_resource":null},{"advanced_attributes_map":"{}","capability_values_json":"[{\"abstract_capability\": \"compression\", \"value\": \"True\", \"uuid\": \"45e0cf41-1842-45e8-b83b-17de54be406d\"}, {\"abstract_capability\": \"thin_provision\", \"value\": \"True\", \"uuid\": \"2fddfc81-2561-40d8-bd84-cec6ec26d551\"}]","component_state":"PENDING_CREATION","logical_free":507879882752,"logical_total":514322333696,"name":"test_or_30:tony_pool","pool_name":"tony_pool","protocol":"fc","storage_system":"9b1cedc0-b476-47f1-8f25-7a7da2b7d91c","uuid":"4cc7fa4e-fa05-47fb-8269-869942e11f86","replication_target_resource":null},{"advanced_attributes_map":"{}","capability_values_json":"[{\"abstract_capability\": \"compression\", \"value\": \"True\", \"uuid\": \"45e0cf41-1842-45e8-b83b-17de54be406d\"}, {\"abstract_capability\": \"thin_provision\", \"value\": \"True\", \"uuid\": \"2fddfc81-2561-40d8-bd84-cec6ec26d551\"}]","component_state":"PENDING_CREATION","logical_free":472446402560,"logical_total":515396075520,"name":"test_or_30:test_pool","pool_name":"test_pool","protocol":"fc","storage_system":"9b1cedc0-b476-47f1-8f25-7a7da2b7d91c","uuid":"41e4e6fb-d670-4db9-8325-464c138dee6f","replication_target_resource":null},{"advanced_attributes_map":"{}","capability_values_json":"[{\"abstract_capability\": \"compression\", \"value\": \"True\", \"uuid\": \"45e0cf41-1842-45e8-b83b-17de54be406d\"}, {\"abstract_capability\": \"thin_provision\", \"value\": \"True\", \"uuid\": \"2fddfc81-2561-40d8-bd84-cec6ec26d551\"}]","component_state":"PENDING_CREATION","logical_free":507879882752,"logical_total":514322333696,"name":"test_or_30:Pool0","pool_name":"Pool0","protocol":"fc","storage_system":"9b1cedc0-b476-47f1-8f25-7a7da2b7d91c","uuid":"4d2eaeaf-0207-4418-bac3-bdae9a4115cc","replication_target_resource":null},{"advanced_attributes_map":"{}","capability_values_json":"[{\"abstract_capability\": \"compression\", \"value\": \"True\", \"uuid\": \"45e0cf41-1842-45e8-b83b-17de54be406d\"}, {\"abstract_capability\": \"thin_provision\", \"value\": \"True\", \"uuid\": \"2fddfc81-2561-40d8-bd84-cec6ec26d551\"}]","component_state":"PENDING_CREATION","logical_free":514322333696,"logical_total":515396075520,"name":"test_or_30:Pool1","pool_name":"Pool1","protocol":"fc","storage_system":"9b1cedc0-b476-47f1-8f25-7a7da2b7d91c","uuid":"03516eb2-d2d9-40c7-921c-6dcf9a835775","replication_target_resource":null},{"advanced_attributes_map":"{}","capability_values_json":"[{\"abstract_capability\": \"compression\", \"value\": \"True\", \"uuid\": \"45e0cf41-1842-45e8-b83b-17de54be406d\"}, {\"abstract_capability\": \"thin_provision\", \"value\": \"True\", \"uuid\": \"2fddfc81-2561-40d8-bd84-cec6ec26d551\"}]","component_state":"PENDING_CREATION","logical_free":515396075520,"logical_total":515396075520,"name":"test_or_30:Pool2","pool_name":"Pool2","protocol":"fc","storage_system":"9b1cedc0-b476-47f1-8f25-7a7da2b7d91c","uuid":"9dbda310-d848-439b-a337-39236b225057","replication_target_resource":null},{"advanced_attributes_map":"{}","capability_values_json":"[{\"abstract_capability\": \"compression\", \"value\": \"True\", \"uuid\": \"45e0cf41-1842-45e8-b83b-17de54be406d\"}, {\"abstract_capability\": \"thin_provision\", \"value\": \"True\", \"uuid\": \"2fddfc81-2561-40d8-bd84-cec6ec26d551\"}]","component_state":"PENDING_CREATION","logical_free":515396075520,"logical_total":515396075520,"name":"test_or_30:Pool3","pool_name":"Pool3","protocol":"fc","storage_system":"9b1cedc0-b476-47f1-8f25-7a7da2b7d91c","uuid":"53cca325-a529-4a97-a756-e86c3342ce9e","replication_target_resource":null},{"advanced_attributes_map":"{}","capability_values_json":"[{\"abstract_capability\": \"compression\", \"value\": \"True\", \"uuid\": \"45e0cf41-1842-45e8-b83b-17de54be406d\"}, {\"abstract_capability\": \"thin_provision\", \"value\": \"True\", \"uuid\": \"2fddfc81-2561-40d8-bd84-cec6ec26d551\"}]","component_state":"PENDING_CREATION","logical_free":515396075520,"logical_total":515396075520,"name":"test_or_30:Pool4","pool_name":"Pool4","protocol":"fc","storage_system":"9b1cedc0-b476-47f1-8f25-7a7da2b7d91c","uuid":"38575e25-8bc6-4e2a-b2c4-bcb2e6c7683f","replication_target_resource":null}]}'
     http_version: null
   recorded_at: Mon, 31 Oct 2022 12:32:39 GMT
 - request:
@@ -500,6 +500,54 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '[{"wwpn":"5001738063CC0193","system_uuid":"78ef7ca4-2ce9-4983-aa49-76dbeedcbedf"}]'
+    http_version: null
+  recorded_at: Mon, 31 Oct 2022 12:32:40 GMT
+- request:
+    method: get
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/service-abstract-capability-values
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+        - OpenAPI-Generator/2.0.0/ruby
+      Content-Type:
+        - application/json
+      Accept:
+        - "*/*"
+      Authorization:
+        - Bearer 9eb68c4775efb26751144a883082f6d464dd6749
+      Expect:
+        - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+        - Mon, 31 Oct 2022 12:32:40 GMT
+      Server:
+        - gunicorn/19.9.0
+      Content-Type:
+        - application/json
+      Vary:
+        - Accept,Cookie
+      Allow:
+        - GET, HEAD, OPTIONS
+      X-Frame-Options:
+        - DENY
+      X-Content-Type-Options:
+        - nosniff
+      Referrer-Policy:
+        - same-origin
+      Transfer-Encoding:
+        - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"count":4,"next":null,"previous":null,"results":[{"abstract_capability":"compression","uuid":"4ce9130a-2070-4b04-b047-ec934a56a331","value":"True"},
+      {"abstract_capability":"compression","uuid":"e9653d16-c805-479f-bae8-91031f07eed6","value":"False"},
+      {"abstract_capability":"thin_provision","uuid":"6c6386eb-564b-4a56-973e-5ccdc90a7e78","value":"True"},
+      {"abstract_capability":"thin_provision","uuid":"3effabe1-d853-442d-b4a1-b39a15268f22","value":"False"}]}'
     http_version: null
   recorded_at: Mon, 31 Oct 2022 12:32:40 GMT
 recorded_with: VCR 5.1.0


### PR DESCRIPTION
filter services and resources by capabilities on volume create:

Basic: filter services by required capabilities and choose an existing service from the filtered list.
Advanced: choose a name for a new service, filter resources by required capabilities, and choose resources to attach to the new service from the filtered list. the new volume(s) will be created for the new service, on one of the attached resources.

changes:
- cloud_volume.rb: 
  -  on params_for_create: get capabilities from provider and use them as options in a multiSelect field. example of capabilities json field from providers api:
![image](https://user-images.githubusercontent.com/106743023/210248054-2f2c7b94-7284-4bec-92e1-295a5818712a.png)
  - on raw_create_volume: build the creation hash according to the selected mode.
- inventory:
  - collect storage manager capabilities from autosde and save them in the providers capabilities json field.
  - collect service and resource capabilities from autosde and save in the capabilities json field in their respective model in miq.

related PR in ui-classic:
https://github.com/ManageIQ/manageiq-ui-classic/pull/8582