### PR TITLE
find resources failure on volume create advanced

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
@@ -21,7 +21,7 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
       creation_hash[:service] = ext_management_system.storage_services.find(options["storage_service_id"]).ems_ref
     else
       creation_hash[:service_name] = options["new_service_name"]
-      creation_hash[:resources] = ext_management_system.storage_resources.find(options["storage_resource_id"].to_a).pluck(:ems_ref)
+      creation_hash[:resources] = ext_management_system.storage_resources.find(options["storage_resource_id"].to_a.pluck("value")).pluck(:ems_ref)
     end
 
     vol_to_create = ext_management_system.autosde_client.VolumeCreate(creation_hash)


### PR DESCRIPTION
`ext_management_system.storage_resources.find(options["storage_resource_id"].to_a).pluck(:ems_ref)`
caused problems, because it searched for an array of hashes like {:label=>"name", :value:"id"}, and `find()` failed. So added another `pluck` to pass only the values (the ids) to `find()`.