### PR TITLE
Added post refresh function to fill empty event columns

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager.rb
@@ -302,10 +302,10 @@ class ManageIQ::Providers::Autosde::StorageManager < ManageIQ::Providers::Storag
 
     events.each do |e|
       physical_storage_uuid = e.full_data[:storage_system]
-      physical_storage = PhysicalStorage.where(:ems_ref => physical_storage_uuid).to_a
+      physical_storage = PhysicalStorage.find_by(:ems_id => ems_id, :ems_ref => physical_storage_uuid)
 
-      e.physical_storage_name = physical_storage[0].name
-      e.physical_storage_id = physical_storage[0].id
+      e.physical_storage_name = physical_storage.name
+      e.physical_storage_id = physical_storage.id
       e.save
     end
   end

--- a/app/models/manageiq/providers/autosde/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager.rb
@@ -298,7 +298,7 @@ class ManageIQ::Providers::Autosde::StorageManager < ManageIQ::Providers::Storag
   end
 
   def self.post_refresh_ems(ems_id, _)
-    events = EmsEvent.where("ems_id = ? AND (physical_storage_id IS NULL OR physical_storage_name IS NULL) LIMIT NULL", ems_id)
+    events = EmsEvent.where("ems_id = ? AND (physical_storage_id IS NULL OR physical_storage_name IS NULL)", ems_id)
 
     events.each do |e|
       physical_storage_uuid = e.full_data[:storage_system]

--- a/app/models/manageiq/providers/autosde/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager.rb
@@ -296,4 +296,17 @@ class ManageIQ::Providers::Autosde::StorageManager < ManageIQ::Providers::Storag
   def self.catalog_types
     {"autosde" => N_("Autosde")}
   end
+
+  def self.post_refresh_ems(ems_id, _)
+    events = EmsEvent.where("ems_id = ? AND (physical_storage_id IS NULL OR physical_storage_name IS NULL) LIMIT NULL", ems_id)
+
+    events.each do |e|
+      physical_storage_uuid = e.full_data[:storage_system]
+      physical_storage = PhysicalStorage.where(:ems_ref => physical_storage_uuid).to_a
+
+      e.physical_storage_name = physical_storage[0].name
+      e.physical_storage_id = physical_storage[0].id
+      e.save
+    end
+  end
 end

--- a/app/models/manageiq/providers/autosde/storage_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/event_catcher/stream.rb
@@ -17,12 +17,6 @@ class ManageIQ::Providers::Autosde::StorageManager::EventCatcher::Stream
   end
 
   def poll_events(&block)
-    physical_storages = []
-    while physical_storages.empty?
-      physical_storages = PhysicalStorage.where(:ems_id => @ems.id)
-      sleep(poll_sleep)
-    end
-
     loop do
       events = @autosde_client.events_get
 

--- a/app/models/manageiq/providers/autosde/storage_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/event_catcher/stream.rb
@@ -17,6 +17,12 @@ class ManageIQ::Providers::Autosde::StorageManager::EventCatcher::Stream
   end
 
   def poll_events(&block)
+    physical_storages = []
+    while physical_storages.empty?
+      physical_storages = PhysicalStorage.where(:ems_id => @ems.id)
+      sleep(poll_sleep)
+    end
+
     loop do
       events = @autosde_client.events_get
 

--- a/app/models/manageiq/providers/autosde/storage_manager/refresher.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/refresher.rb
@@ -1,5 +1,4 @@
 class ManageIQ::Providers::Autosde::StorageManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
-
   def post_process_refresh_classes
     [ManageIQ::Providers::Autosde::StorageManager]
   end

--- a/app/models/manageiq/providers/autosde/storage_manager/refresher.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/refresher.rb
@@ -1,2 +1,6 @@
 class ManageIQ::Providers::Autosde::StorageManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
+
+  def post_process_refresh_classes
+    [ManageIQ::Providers::Autosde::StorageManager]
+  end
 end


### PR DESCRIPTION
Since the activation of the events worker was when the ems was set up, events were received without a physical storage name, which led to errors in the events chart in the EMS dashboard.
The fix was to add a condition to the start of the events worker, so the polling would start when physical storage is added to the EMS.