### PR TITLE
refresh bulk of volumes and get object_id as array

### DIFF
--- a/manageiq-providers-autosde.gemspec
+++ b/manageiq-providers-autosde.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "autosde_openapi_client", "~> 2.3.0"
+  spec.add_dependency "autosde_openapi_client", "~> 3.0.1"
   spec.add_dependency "typhoeus", "~> 1.4"
 
   spec.add_development_dependency "manageiq-style"


### PR DESCRIPTION
When an object is created, it's auto-refreshed by the refresh worker once its status is success. But when a bulk of volumes is created, only one of the volumes was being refreshed because it got only one of the created volumes in the object_id.

I changed that to refresh all the ems (I would prefer it to refresh only cloud volumes or only those specific volumes but I don't think those options are supported).

Other than that, the object_id is now being received as a list, that's part of the changes of this PR. It's still in [wip] because the gem hasn't been updated yet.