### PR TITLE
Add system type to the asset detail for textual summary

### DIFF
--- a/app/models/manageiq/providers/autosde/inventory/parser/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/inventory/parser/storage_manager.rb
@@ -45,12 +45,13 @@ class ManageIQ::Providers::Autosde::Inventory::Parser::StorageManager < ManageIQ
 
   def physical_storages
     collector.physical_storages.each do |storage|
-      persister.physical_storages.build(
+      physical_storage = persister.physical_storages.build(
         :name                    => storage.name,
         :ems_ref                 => storage.uuid,
         :physical_storage_family => persister.physical_storage_families.lazy_find(storage.system_type.uuid),
         :health_state            => storage.status
       )
+      persister.physical_storage_details.build(:resource => physical_storage, :model => storage.system_type.name)
     end
   end
 

--- a/app/models/manageiq/providers/autosde/inventory/persister/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/inventory/persister/storage_manager.rb
@@ -18,5 +18,16 @@ class ManageIQ::Providers::Autosde::Inventory::Persister::StorageManager < Manag
     add_collection(storage, :cloud_volumes)
     add_collection(storage, :ext_management_system)
     add_collection(storage, :storage_service_resource_attachments)
+    add_physical_storage_details
+  end
+
+  def add_physical_storage_details
+    add_collection(storage, :physical_storage_details) do |builder|
+      builder.add_properties(
+        :model_class                  => ::AssetDetail,
+        :manager_ref                  => %i[resource],
+        :parent_inventory_collections => %i[physical_storages]
+      )
+    end
   end
 end


### PR DESCRIPTION
We added the physical storage family (the storage model) to the correct place.

<img width="822" alt="Screenshot 2023-02-08 at 11 33 42" src="https://user-images.githubusercontent.com/74841666/217490935-d988e2ba-09ab-4761-ba42-d90f24b99583.png">
