### PR TITLE
Added default option to volume creation mode

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
@@ -136,13 +136,14 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
                             {:type => "min-number-value", :value => 1, :message => _('Must be greater than or equal to 1')}],
         },
         {
-          :component  => "radio",
-          :name       => "mode",
-          :id         => "mode",
-          :label      => _("Mode"),
-          :options    => [{:label => 'Basic', :value => 'Basic'}, {:label => 'Advanced', :value => 'Advanced'}],
-          :isRequired => true,
-          :validate   => [{:type => "required"}]
+          :component    => "radio",
+          :name         => "mode",
+          :id           => "mode",
+          :label        => _("Mode"),
+          :initialValue => 'Basic',
+          :options      => [{:label => 'Basic', :value => 'Basic',}, {:label => 'Advanced', :value => 'Advanced'}],
+          :isRequired   => true,
+          :validate     => [{:type => "required"}]
         },
         {
           :component  => "select",


### PR DESCRIPTION
Added a default option to volume creation mode, this make more sense now
Before - initial state of the form: 
![Screenshot 2023-02-12 at 12 56 31](https://user-images.githubusercontent.com/62609377/218308125-30b19be5-22cc-48f1-9077-3d81c362af56.png)

After: 
![Screenshot 2023-02-12 at 13 18 31](https://user-images.githubusercontent.com/62609377/218308162-d673d26d-97fe-42e5-aa9c-57332448f859.png)
