### PR TITLE
pass service capabilities for the new service created in volume create advanced mode

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
@@ -22,6 +22,7 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
     else
       creation_hash[:service_name] = options["new_service_name"]
       creation_hash[:resources] = ext_management_system.storage_resources.find(options["storage_resource_id"].to_a.pluck("value")).pluck(:ems_ref)
+      creation_hash[:service_capabilities] = options['required_capabilities'].map { |capability| capability["value"] }
     end
 
     vol_to_create = ext_management_system.autosde_client.VolumeCreate(creation_hash)

--- a/manageiq-providers-autosde.gemspec
+++ b/manageiq-providers-autosde.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "autosde_openapi_client", "~> 2.2.0"
+  spec.add_dependency "autosde_openapi_client", "~> 2.3.0"
   spec.add_dependency "typhoeus", "~> 1.4"
 
   spec.add_development_dependency "manageiq-style"


### PR DESCRIPTION
the `required_capabilities` chosen in volume create advanced mode form are now passed to autosde.

the gemspec was updated for the new minor bump which enables this (2.3.0).