### PR TITLE
Implement cloud snapshot collector, list page, create & delete methods

### DIFF
--- a/app/models/manageiq/providers/autosde/inventory/collector/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/inventory/collector/storage_manager.rb
@@ -27,6 +27,10 @@ class ManageIQ::Providers::Autosde::Inventory::Collector::StorageManager < Manag
     @cloud_volumes ||= @manager.autosde_client.VolumeApi.volumes_get
   end
 
+  def cloud_volume_snapshots
+    @cloud_volume_snapshots ||= @manager.autosde_client.SnapshotApi.snapshots_get
+  end
+  
   def storage_services
     @storage_services ||= @manager.autosde_client.ServiceApi.services_get
   end

--- a/app/models/manageiq/providers/autosde/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/autosde/inventory/collector/target_collection.rb
@@ -37,7 +37,7 @@ class ManageIQ::Providers::Autosde::Inventory::Collector::TargetCollection < Man
   end
 
   def cloud_volume_snapshots
-    return [] if references(:cloud_volumes).blank?
+    return [] if references(:cloud_volume_snapshots).blank?
 
     @cloud_volume_snapshots ||= @manager.autosde_client.SnapshotApi.snapshots_get.select { |s| references(:cloud_volume_snapshots).include?(s.uuid) }
   end

--- a/app/models/manageiq/providers/autosde/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/autosde/inventory/collector/target_collection.rb
@@ -36,6 +36,12 @@ class ManageIQ::Providers::Autosde::Inventory::Collector::TargetCollection < Man
     @cloud_volumes ||= @manager.autosde_client.VolumeApi.volumes_get.select { |s| references(:cloud_volumes).include?(s.uuid) }
   end
 
+  def cloud_volume_snapshots
+    return [] if references(:cloud_volumes).blank?
+
+    @cloud_volume_snapshots ||= @manager.autosde_client.SnapshotApi.snapshots_get.select { |s| references(:cloud_volume_snapshots).include?(s.uuid) }
+  end
+
   def storage_services
     return [] if references(:storage_services).blank?
 
@@ -80,6 +86,8 @@ class ManageIQ::Providers::Autosde::Inventory::Collector::TargetCollection < Man
         add_target!(:cloud_volumes, target.ems_ref)
       when StorageService
         add_target!(:storage_services, target.ems_ref)
+      when CloudVolumeSnapshot
+        add_target!(:cloud_volume_snapshots, target.ems_ref)
       end
     end
   end

--- a/app/models/manageiq/providers/autosde/inventory/parser/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/inventory/parser/storage_manager.rb
@@ -158,12 +158,12 @@ class ManageIQ::Providers::Autosde::Inventory::Parser::StorageManager < ManageIQ
     collector.cloud_volume_snapshots.each do |snapshot|
       cloud_volume = persister.cloud_volumes.find(snapshot.volume)
       persister.cloud_volume_snapshots.build(
-        :name             => snapshot.name,
-        :size             => cloud_volume.size,
-        :cloud_volume     => cloud_volume,
-        :ems_ref          => snapshot.uuid,
-        :description      => snapshot.description,
-        :status           => snapshot.component_state
+        :name         => snapshot.name,
+        :size         => cloud_volume.size,
+        :cloud_volume => cloud_volume,
+        :ems_ref      => snapshot.uuid,
+        :description  => snapshot.description,
+        :status       => snapshot.component_state
       )
     end
   end

--- a/app/models/manageiq/providers/autosde/inventory/parser/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/inventory/parser/storage_manager.rb
@@ -20,6 +20,7 @@ class ManageIQ::Providers::Autosde::Inventory::Parser::StorageManager < ManageIQ
     san_addresses
     storage_services
     cloud_volumes
+    cloud_volume_snapshots
     volume_mappings
     wwpn_candidates
     storage_service_resource_attachments
@@ -149,6 +150,20 @@ class ManageIQ::Providers::Autosde::Inventory::Parser::StorageManager < ManageIQ
         :storage_service  => persister.storage_services.lazy_find(volume.service),
         :status           => volume.component_state,
         :health_state     => volume.status
+      )
+    end
+  end
+
+  def cloud_volume_snapshots
+    collector.cloud_volume_snapshots.each do |snapshot|
+      cloud_volume = persister.cloud_volumes.find(snapshot.volume)
+      persister.cloud_volume_snapshots.build(
+        :name             => snapshot.name,
+        :size             => cloud_volume.size,
+        :cloud_volume     => cloud_volume,
+        :ems_ref          => snapshot.uuid,
+        :description      => snapshot.description,
+        :status           => snapshot.component_state
       )
     end
   end

--- a/app/models/manageiq/providers/autosde/inventory/persister/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/inventory/persister/storage_manager.rb
@@ -16,6 +16,7 @@ class ManageIQ::Providers::Autosde::Inventory::Persister::StorageManager < Manag
     add_collection(storage, :storage_resources)
     add_collection(storage, :storage_services)
     add_collection(storage, :cloud_volumes)
+    add_collection(storage, :cloud_volume_snapshots)
     add_collection(storage, :ext_management_system)
     add_collection(storage, :storage_service_resource_attachments)
     add_physical_storage_details

--- a/app/models/manageiq/providers/autosde/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager.rb
@@ -1,6 +1,7 @@
 class ManageIQ::Providers::Autosde::StorageManager < ManageIQ::Providers::StorageManager
   require_nested :AutosdeClient
   require_nested :CloudVolume
+  require_nested :CloudVolumeSnapshot
   require_nested :ClusterVolumeMapping
   require_nested :HostInitiatorGroup
   require_nested :HostInitiator
@@ -19,6 +20,7 @@ class ManageIQ::Providers::Autosde::StorageManager < ManageIQ::Providers::Storag
   supports :storage_service_create
   supports :update
   supports :volume_resizing
+  supports :cloud_volume_snapshots
   supports :cloud_volume_create
   supports :cloud_volume
   supports :catalog

--- a/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
@@ -4,6 +4,10 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
   supports :update do
     unsupported_reason_add(:update, _("the volume is not connected to an active provider")) unless ext_management_system
   end
+  supports :snapshot_create do
+    unsupported_reason_add(:snapshot_create, _("the volume is not connected to an active provider")) unless ext_management_system
+  end
+
   # cloud volume delete functionality is not supported for now
   supports_not :delete
   supports_not :safe_delete

--- a/app/models/manageiq/providers/autosde/storage_manager/cloud_volume_snapshot.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/cloud_volume_snapshot.rb
@@ -1,0 +1,38 @@
+class ManageIQ::Providers::Autosde::StorageManager::CloudVolumeSnapshot < ::CloudVolumeSnapshot
+  supports :create
+  supports :delete
+
+  def self.raw_create_snapshot(cloud_volume, options = {})
+    ext_management_system = cloud_volume.ext_management_system
+    creation_hash = {
+      :name        => options[:name],
+      :description => options[:description],
+      :volume      => cloud_volume.ems_ref
+    }
+    snapshot_object = ext_management_system.autosde_client.SnapshotCreate(creation_hash)
+
+    task_id = ext_management_system.autosde_client.SnapshotApi.snapshots_post(snapshot_object).task_id
+    options = {
+      :target_class   => :cloud_volume_snapshots,
+      :target_id      => nil,
+      :ems_id         => ext_management_system.id,
+      :native_task_id => task_id,
+      :interval       => 10.seconds,
+      :target_option  => "new"
+    }
+    ext_management_system.class::EmsRefreshWorkflow.create_job(options).tap(&:signal_start)
+  end
+
+  def raw_delete_snapshot
+    task_id = ext_management_system.autosde_client.SnapshotApi.snapshots_pk_delete(ems_ref).task_id
+    options = {
+      :target_id      => id,
+      :target_class   => self.class.name,
+      :ems_id         => ext_management_system.id,
+      :native_task_id => task_id,
+      :interval       => 20.seconds,
+      :target_option  => "existing"
+    }
+    ext_management_system.class::EmsRefreshWorkflow.create_job(options).tap(&:signal_start)
+  end
+end

--- a/spec/models/manageiq/providers/autosde/storage_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/autosde/storage_manager/refresher_spec.rb
@@ -26,6 +26,7 @@ describe ManageIQ::Providers::Autosde::StorageManager::Refresher do
           assert_specific_host_volume_mapping
           assert_specific_cluster_volume_mapping
           assert_specific_storage_service_resource_attachment
+          assert_specific_cloud_volume_snapshot
         end
       end
     end
@@ -237,6 +238,7 @@ describe ManageIQ::Providers::Autosde::StorageManager::Refresher do
       expect(ems.cluster_volume_mappings.count).to(eq(1))
       expect(ems.host_volume_mappings.count).to(eq(7))
       expect(ems.storage_service_resource_attachments.count).to(eq(9))
+      expect(ems.cloud_volume_snapshots.count).to(eq(1))
     end
 
     def assert_specific_physical_storage
@@ -377,6 +379,15 @@ describe ManageIQ::Providers::Autosde::StorageManager::Refresher do
                               :storage_service_id  => ems.storage_services.find_by(:ems_ref => "5189b322-c4ce-47ea-b267-381e8c4baab5"),
                               :ems_ref             => "f0ecb715-19a1-4e74-b6f5-5c428a9c741d"
                             ))
+    end
+
+    def assert_specific_cloud_volume_snapshot
+      cloud_volume_snapshot = ems.cloud_volume_snapshots.find_by(:ems_ref => "73c1df37-ed05-45cd-8551-a838557fbbdc")
+      expect(cloud_volume_snapshot).to(have_attributes(
+                                         :cloud_volume => ems.cloud_volumes.find_by(:ems_ref => "5172e7ba-c22e-405d-9380-0b83c6873657"),
+                                         :name         => "snapshot-5d46cdbc-ade3-4a46-b232-bd1b220e62bc",
+                                         :ems_ref      => "73c1df37-ed05-45cd-8551-a838557fbbdc"
+                                       ))
     end
   end
 end

--- a/spec/models/manageiq/providers/autosde/storage_manager/refresher_spec_v2.rb
+++ b/spec/models/manageiq/providers/autosde/storage_manager/refresher_spec_v2.rb
@@ -27,6 +27,7 @@ describe ManageIQ::Providers::Autosde::StorageManager::Refresher do
           assert_specific_host_volume_mapping
           assert_specific_cluster_volume_mapping
           assert_specific_storage_service_resource_attachment
+          assert_specific_cloud_volume_snapshot
         end
       end
     end
@@ -238,6 +239,7 @@ describe ManageIQ::Providers::Autosde::StorageManager::Refresher do
       expect(ems.cluster_volume_mappings.count).to(eq(1))
       expect(ems.host_volume_mappings.count).to(eq(2))
       expect(ems.storage_service_resource_attachments.count).to(eq(9))
+      expect(ems.cloud_volume_snapshots.count).to(eq(1))
     end
 
     def assert_specific_physical_storage
@@ -379,6 +381,15 @@ describe ManageIQ::Providers::Autosde::StorageManager::Refresher do
                               :ems_ref             => "f0ecb715-19a1-4e74-b6f5-5c428a9c741d",
                               :type                => "ManageIQ::Providers::Autosde::StorageManager::StorageServiceResourceAttachment"
                             ))
+    end
+    def assert_specific_cloud_volume_snapshot
+      cloud_volume_snapshot = ems.cloud_volume_snapshots.find_by(:ems_ref => "73c1df37-ed05-45cd-8551-a838557fbbdc")
+      expect(cloud_volume_snapshot).to(have_attributes(
+                                         :cloud_volume => ems.cloud_volumes.find_by(:ems_ref => "5172e7ba-c22e-405d-9380-0b83c6873657"),
+                                         :name         => "snapshot-5d46cdbc-ade3-4a46-b232-bd1b220e62bc",
+                                         :ems_ref      => "73c1df37-ed05-45cd-8551-a838557fbbdc",
+                                         :type         => "ManageIQ::Providers::Autosde::StorageManager::CloudVolumeSnapshot"
+                                       ))
     end
   end
 end

--- a/spec/vcr_cassettes/ems_refresh_v1.yml
+++ b/spec/vcr_cassettes/ems_refresh_v1.yml
@@ -585,4 +585,49 @@ http_interactions:
       string: '[{"compliant":true,"service":"5189b322-c4ce-47ea-b267-381e8c4baab5","storage_resource":"f60e8f31-1d22-48fe-a79c-319b6c3613aa","uuid":"f0ecb715-19a1-4e74-b6f5-5c428a9c741d"},{"compliant":true,"service":"38abdf9c-92a7-438f-84e2-e1a069cc7b73","storage_resource":"2ffb219c-5f92-43d8-8917-356c4557edcb","uuid":"fa02ceb2-e729-4fe1-bcb6-4b03168fb169"},{"compliant":true,"service":"66d60892-6430-4681-883a-61ed0db50db6","storage_resource":"9fc3ed70-ea07-4db7-8118-6fb46301d90d","uuid":"8fb873a4-fd17-4cbc-99f4-875eba1c95ae"},{"compliant":true,"service":"5a3bb3d2-caf4-4b3f-915d-edfa0e7269ed","storage_resource":"d923a880-96cf-47d1-ab8e-ceb872c2e4bb","uuid":"158c03ac-fb62-46b2-9170-c6f0ebb91549"},{"compliant":true,"service":"3f692948-52c8-411d-ab8a-2777f025ba98","storage_resource":"34fd30ba-d1f8-41b9-9fa1-e6c41950a133","uuid":"bb6ea1ef-33a8-4651-85c5-cc155c7351c0"},{"compliant":true,"service":"6cf7190a-15f0-4f62-9d64-31f275de5722","storage_resource":"d7e04c01-3944-499f-86f5-d5406bf76182","uuid":"b6af6083-e39c-4f8a-b1ea-134637bc1ada"},{"compliant":true,"service":"468a4250-aa52-4d2a-a86c-9a557ebd6307","storage_resource":"b30612fe-a0da-43f5-9b3a-e27a4504a5c3","uuid":"fe5862a3-fc3b-4816-8be8-5bfbd74478d6"},{"compliant":true,"service":"61de684a-203e-4505-b6be-47f848ea0069","storage_resource":"1db314a1-cd66-4289-8586-abb58684c870","uuid":"4b1387d9-fac7-453d-9844-21df4b43824b"},{"compliant":true,"service":"0b344f0d-0066-4a66-92b5-53995cc26d2f","storage_resource":"46175ca2-0695-4ae5-baab-00ed5b9155e4","uuid":"0715cd74-ea55-479f-8bb0-92f1e6e852de"}]'
     http_version: null
   recorded_at: Mon, 25 Oct 2021 09:51:49 GMT
+- request:
+    method: get
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/snapshots
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+        - OpenAPI-Generator/2.0.0/ruby
+      Content-Type:
+        - application/json
+      Accept:
+        - "*/*"
+      Authorization:
+        - Bearer c02cd8466a168eb5d5ce2febf6f8df77b01ae60c
+      Expect:
+        - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+        - Thu, 23 Mar 2022 14:19:07 GMT
+      Server:
+        - gunicorn/19.9.0
+      Content-Type:
+        - application/json
+      Vary:
+        - Accept,Cookie
+      Allow:
+        - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+        - DENY
+      X-Content-Type-Options:
+        - nosniff
+      Referrer-Policy:
+        - same-origin
+      Transfer-Encoding:
+        - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"component_state":"CREATED","description":"Snapshot of volume by name vik_1","name":"snapshot-5d46cdbc-ade3-4a46-b232-bd1b220e62bc","name_in_storage":"snapshot-5d46cdbc-ade3-4a46-b232-bd1b220e62bc","uuid":"73c1df37-ed05-45cd-8551-a838557fbbdc","volume":"5172e7ba-c22e-405d-9380-0b83c6873657"}]'
+    http_version: null
+  recorded_at: Thu, 23 Mar 2022 14:19:07 GMT
 recorded_with: VCR 5.1.0

--- a/spec/vcr_cassettes/ems_refresh_v2.yml
+++ b/spec/vcr_cassettes/ems_refresh_v2.yml
@@ -595,4 +595,49 @@ http_interactions:
       string: '{"count":9,"next":null,"previous":null,"results":[{"compliant":true,"service":"5189b322-c4ce-47ea-b267-381e8c4baab5","storage_resource":"f60e8f31-1d22-48fe-a79c-319b6c3613aa","uuid":"f0ecb715-19a1-4e74-b6f5-5c428a9c741d"},{"compliant":true,"service":"38abdf9c-92a7-438f-84e2-e1a069cc7b73","storage_resource":"2ffb219c-5f92-43d8-8917-356c4557edcb","uuid":"fa02ceb2-e729-4fe1-bcb6-4b03168fb169"},{"compliant":true,"service":"66d60892-6430-4681-883a-61ed0db50db6","storage_resource":"9fc3ed70-ea07-4db7-8118-6fb46301d90d","uuid":"8fb873a4-fd17-4cbc-99f4-875eba1c95ae"},{"compliant":true,"service":"5a3bb3d2-caf4-4b3f-915d-edfa0e7269ed","storage_resource":"d923a880-96cf-47d1-ab8e-ceb872c2e4bb","uuid":"158c03ac-fb62-46b2-9170-c6f0ebb91549"},{"compliant":true,"service":"3f692948-52c8-411d-ab8a-2777f025ba98","storage_resource":"34fd30ba-d1f8-41b9-9fa1-e6c41950a133","uuid":"bb6ea1ef-33a8-4651-85c5-cc155c7351c0"},{"compliant":true,"service":"6cf7190a-15f0-4f62-9d64-31f275de5722","storage_resource":"d7e04c01-3944-499f-86f5-d5406bf76182","uuid":"b6af6083-e39c-4f8a-b1ea-134637bc1ada"},{"compliant":true,"service":"468a4250-aa52-4d2a-a86c-9a557ebd6307","storage_resource":"b30612fe-a0da-43f5-9b3a-e27a4504a5c3","uuid":"fe5862a3-fc3b-4816-8be8-5bfbd74478d6"},{"compliant":true,"service":"61de684a-203e-4505-b6be-47f848ea0069","storage_resource":"1db314a1-cd66-4289-8586-abb58684c870","uuid":"4b1387d9-fac7-453d-9844-21df4b43824b"},{"compliant":true,"service":"0b344f0d-0066-4a66-92b5-53995cc26d2f","storage_resource":"46175ca2-0695-4ae5-baab-00ed5b9155e4","uuid":"0715cd74-ea55-479f-8bb0-92f1e6e852de"}]}'
     http_version: null
   recorded_at: Mon, 31 Oct 2022 12:32:40 GMT
+- request:
+    method: get
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/snapshots
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+        - OpenAPI-Generator/2.0.0/ruby
+      Content-Type:
+        - application/json
+      Accept:
+        - "*/*"
+      Authorization:
+        - Bearer c02cd8466a168eb5d5ce2febf6f8df77b01ae60c
+      Expect:
+        - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+        - Thu, 23 Mar 2022 14:19:07 GMT
+      Server:
+        - gunicorn/19.9.0
+      Content-Type:
+        - application/json
+      Vary:
+        - Accept,Cookie
+      Allow:
+        - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+        - DENY
+      X-Content-Type-Options:
+        - nosniff
+      Referrer-Policy:
+        - same-origin
+      Transfer-Encoding:
+        - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"count":1,"next":null,"previous":null,"results":[{"component_state":"CREATED","description":"Snapshot of volume by name vik_1","name":"snapshot-5d46cdbc-ade3-4a46-b232-bd1b220e62bc","name_in_storage":"snapshot-5d46cdbc-ade3-4a46-b232-bd1b220e62bc","uuid":"73c1df37-ed05-45cd-8551-a838557fbbdc","volume":"5172e7ba-c22e-405d-9380-0b83c6873657"}]}'
+    http_version: null
+  recorded_at: Thu, 23 Mar 2022 14:19:07 GMT
 recorded_with: VCR 5.1.0

--- a/spec/vcr_cassettes/get_cloud_volume_snapshots_v1.yml
+++ b/spec/vcr_cassettes/get_cloud_volume_snapshots_v1.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/snapshots
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/2.0.0/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - "*/*"
+      Authorization:
+      - Bearer c02cd8466a168eb5d5ce2febf6f8df77b01ae60c
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Mar 2022 14:19:07 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"component_state":"CREATED","description":"Snapshot of volume by name vik_1","name":"snapshot-5d46cdbc-ade3-4a46-b232-bd1b220e62bc","name_in_storage":"snapshot-5d46cdbc-ade3-4a46-b232-bd1b220e62bc","uuid":"73c1df37-ed05-45cd-8551-a838557fbbdc","volume":"5172e7ba-c22e-405d-9380-0b83c6873657"}]'
+    http_version: null
+  recorded_at: Thu, 23 Mar 2022 14:19:07 GMT
+recorded_with: VCR 5.1.0

--- a/spec/vcr_cassettes/get_cloud_volume_snapshots_v2.yml
+++ b/spec/vcr_cassettes/get_cloud_volume_snapshots_v2.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://autosde-appliance-host/site-manager/api/v1/engine/snapshots
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/2.0.0/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - "*/*"
+      Authorization:
+      - Bearer c02cd8466a168eb5d5ce2febf6f8df77b01ae60c
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Mar 2022 14:19:07 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"count":1,"next":null,"previous":null,"results":[{"component_state":"CREATED","description":"Snapshot of volume by name vik_1","name":"snapshot-5d46cdbc-ade3-4a46-b232-bd1b220e62bc","name_in_storage":"snapshot-5d46cdbc-ade3-4a46-b232-bd1b220e62bc","uuid":"73c1df37-ed05-45cd-8551-a838557fbbdc","volume":"5172e7ba-c22e-405d-9380-0b83c6873657"}]}'
+    http_version: null
+  recorded_at: Thu, 23 Mar 2022 14:19:07 GMT
+recorded_with: VCR 5.1.0


### PR DESCRIPTION
We have developed an integration with a new resource type - "cloud volume snapshot" on the Autosde side. Now, we can provide a list of snapshots from the attached physical storage, create a new one based on a particular volume object and delete it - by using the Autosde rest endpoint (The Autosde GEM is already updated with these new features).
Following these new features, I have added to our (MIQ Autosde provider) collector and refresher to pull snapshots from Autosde and show them in the right place - Cloud Volume Snapshots. I also added the counter component to the provider dashboard.

List page:
![image](https://user-images.githubusercontent.com/33315712/218869146-daaa2529-3fdd-45e9-ac3c-2570896271a0.png)

Snapshot summary page:
![image](https://user-images.githubusercontent.com/33315712/218869307-c048bcaf-2d0c-4440-b424-dc4d41eac5da.png)

Dashboard:
![image](https://user-images.githubusercontent.com/33315712/218869365-be4953bf-936c-4728-bc7c-b682b6fb9078.png)

Create snapshot from cloud volume:
1.
![image](https://user-images.githubusercontent.com/33315712/220778117-7cc9327c-6ec9-4429-a310-8ddc7453c976.png)
2.
![image](https://user-images.githubusercontent.com/33315712/220781667-0899679b-7972-42c8-9dcd-87a2ffca9968.png)

Delete button exists as well at the snapshots page

# related PRs:
- https://github.com/ManageIQ/manageiq/pull/22359
- https://github.com/ManageIQ/manageiq-ui-classic/pull/8647
- https://github.com/ManageIQ/manageiq-api/pull/1205