### PR TITLE
select storage resources to attach to in storage service create

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
@@ -19,16 +19,20 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
 
     if options['mode'] == 'Basic'
       creation_hash[:service] = ext_management_system.storage_services.find(options["storage_service_id"]).ems_ref
+      target_class = :cloud_volumes
+      target_option = "new"
     else
       creation_hash[:service_name] = options["new_service_name"]
       creation_hash[:resources] = ext_management_system.storage_resources.find(options["storage_resource_id"].to_a.pluck("value")).pluck(:ems_ref)
       creation_hash[:service_capabilities] = options['required_capabilities'].map { |capability| capability["value"] }
+      target_class = nil
+      target_option = "ems"
     end
 
     vol_to_create = ext_management_system.autosde_client.VolumeCreate(creation_hash)
     task_id = ext_management_system.autosde_client.VolumeApi.volumes_post(vol_to_create).task_id
 
-    create_refresh_task(nil, task_id, :cloud_volumes, ext_management_system, "new")
+    create_refresh_task(nil, task_id, target_class, ext_management_system, target_option)
   end
 
   # ================= delete  ================
@@ -140,7 +144,7 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
           :component    => "radio",
           :name         => "mode",
           :id           => "mode",
-          :label        => _("Mode"),
+          :label        => _("Mode: Create volume(s) using an existing storage service or create a new service as well"),
           :initialValue => 'Basic',
           :options      => [{:label => 'Basic', :value => 'Basic',}, {:label => 'Advanced', :value => 'Advanced'}],
           :isRequired   => true,

--- a/app/models/manageiq/providers/autosde/storage_manager/storage_service.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/storage_service.rb
@@ -7,6 +7,7 @@ class ManageIQ::Providers::Autosde::StorageManager::StorageService < ::StorageSe
       :name                  => options['name'],
       :description           => options['description'].nil? ? "none" : options['description'],
       :capability_value_list => options['required_capabilities'].map { |capability| capability["value"] },
+      :resources             => ext_management_system.storage_resources.find(options["storage_resource_id"].to_a.pluck("value")).pluck(:ems_ref),
       # currently only one default optional value is added in the backend for each of these,
       # but in the future we might add them as miq models with more optional values:
       :project               => "",


### PR DESCRIPTION
- storage service: ems refresh for service create and delete is general and not targeted, so that service-resource-attachments will be refreshed as well.

- cloud volume: create performs a general refresh if:
  - mode was advanced: so that the new service and its attachments to the selected resources will be refreshed as well.
  - count > 1: so that all the new volumes will be refreshed

- [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/8662

creating a storage with attached resources now enables to select it in volume create basic mode:
![image](https://user-images.githubusercontent.com/106743023/220918988-738e7d4f-f540-406d-8c77-335e8d9f1e23.png)

and the volumes will be created on one of its attached resources:
![image](https://user-images.githubusercontent.com/106743023/220919224-e8546f23-5ce9-4cb4-b109-b35a3144bca1.png)

