### PR TITLE
split service create capabilities to separate single select fields

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
@@ -22,9 +22,10 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
       target_class = :cloud_volumes
       target_option = "new"
     else
+      creation_hash[:service_capabilities] = options.slice(*ext_management_system.capabilities.keys).values
+      creation_hash[:service_capabilities].delete("-1")
       creation_hash[:service_name] = options["new_service_name"]
       creation_hash[:resources] = ext_management_system.storage_resources.find(options["storage_resource_id"].to_a.pluck("value")).pluck(:ems_ref)
-      creation_hash[:service_capabilities] = options['required_capabilities'].map { |capability| capability["value"] }
       target_class = nil
       target_option = "ems"
     end
@@ -112,7 +113,7 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
   end
 
   def self.params_for_create(provider)
-    capabilities = provider.capabilities.map do |name, values|
+    capabilities = provider.capabilities.reject { |cap| cap == 'data_reduction' }.map do |name, values|
       {
         :component    => "select",
         :id           => name,

--- a/app/models/manageiq/providers/autosde/storage_manager/storage_service.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/storage_service.rb
@@ -3,10 +3,13 @@ class ManageIQ::Providers::Autosde::StorageManager::StorageService < ::StorageSe
   supports :delete
 
   def self.raw_create_storage_service(ext_management_system, options = {})
+    capability_value_list = options.slice(*ext_management_system.capabilities.keys).values
+    capability_value_list.delete("-1")
+
     creation_hash = {
       :name                  => options['name'],
       :description           => options['description'].nil? ? "none" : options['description'],
-      :capability_value_list => options['required_capabilities'].map { |capability| capability["value"] },
+      :capability_value_list => capability_value_list,
       :resources             => ext_management_system.storage_resources.find(options["storage_resource_id"].to_a.pluck("value")).pluck(:ems_ref),
       # currently only one default optional value is added in the backend for each of these,
       # but in the future we might add them as miq models with more optional values:
@@ -42,21 +45,29 @@ class ManageIQ::Providers::Autosde::StorageManager::StorageService < ::StorageSe
   end
 
   def self.params_for_create(provider)
-    capabilities = provider.capabilities.map do |capability|
-      {:label => "#{capability['abstract_capability']}: #{capability['value']}", :value => capability['uuid']}
+    capabilities = provider.capabilities.reject { |cap| cap == 'data_reduction' }.map do |name, values|
+      {
+        :component    => "select",
+        :id           => name,
+        :name         => name,
+        :label        => _(name.split("_").join(" ").capitalize),
+        :initialValue => "-1",
+        :options      => [
+          {:label => "N/A", :value => "-1"},
+          {:label => values[0]['value'], :value => values[0]['uuid']},
+          {:label => values[1]['value'], :value => values[1]['uuid']}
+        ]
+      }
     end
 
     {
       :fields => [
         {
-          :component  => "select",
-          :name       => "required_capabilities",
-          :id         => "required_capabilities",
-          :label      => _("Required Capabilities (filters by exact match)"),
-          :options    => capabilities,
-          :isRequired => true,
-          :isMulti    => true,
-          :validate   => [{:type => "required"}]
+          :component => "sub-form",
+          :name      => "required_capabilities",
+          :id        => "required_capabilities",
+          :title     => _("Required Capabilities"),
+          :fields    => capabilities
         }
       ]
     }


### PR DESCRIPTION
part of issue:
- [ ] https://github.com/ManageIQ/manageiq-ui-classic/issues/8701
co-dependent on the ui-pr there

also includes a fix for properly passing `service_capabilities` in volume create advanced.

_**edit:** added another fix in both service and volume params for create, to filter out a newly added but not-yet-relevant capability ("data reduction")_