### PR TITLE
added password decryption in validate and create

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
@@ -25,7 +25,7 @@ class ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage < ::Physical
     validation_object = ext_management_system.autosde_client.StorageSystemCreate(
       :management_ip => options['management_ip'],
       :user          => options['user'],
-      :password      => options['password'],
+      :password      => ManageIQ::Password.try_decrypt(options['password']),
       :system_type   => PhysicalStorageFamily.find(options['physical_storage_family_id']).name
     )
     ext_management_system.autosde_client.ValidateSystemApi.validate_system_post(validation_object)
@@ -53,7 +53,7 @@ class ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage < ::Physical
 
   def self.raw_create_physical_storage(ext_management_system, options = {})
     sys_to_create = ext_management_system.autosde_client.StorageSystemCreate(
-      :password                       => options['password'],
+      :password                       => ManageIQ::Password.try_decrypt(options['password']),
       :user                           => options['user'],
       :system_type                    => PhysicalStorageFamily.find(options['physical_storage_family_id']).name,
       :management_ip                  => options['management_ip'],


### PR DESCRIPTION
As suggested by Adam, I added physical storage password decryption in validate and create function.
This PR is related to ManageIQ core repo PR: https://github.com/ManageIQ/manageiq/pull/22442 

Password in logs after the changes:
![Screenshot 2023-04-04 at 9 22 51](https://user-images.githubusercontent.com/62609377/229705463-1c7828a1-ef3d-4246-a9e8-361d6ba2244c.png)
![Screenshot 2023-04-04 at 9 23 11](https://user-images.githubusercontent.com/62609377/229705489-2d612067-ddee-4cd9-86f5-5de06a0831fd.png)


Discussion with Adam:
<img width="1227" alt="Adam discuss encrypt" src="https://user-images.githubusercontent.com/62609377/229705867-7040f81b-1f15-4670-993c-21b0513f803d.png">

