### PR TITLE
730715 custom task queuing massage

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
@@ -40,6 +40,16 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
     create_refresh_task(nil, task_id, target_class, ext_management_system, target_option)
   end
 
+  def self.create_volume_queue(userid, ext_management_system, options = {})
+    task_opts = {
+      :action => "Queuing create Cloud Volume for user #{userid}",
+      :userid => userid
+    }
+
+    super(userid, ext_management_system, options, task_opts)
+  end
+
+
   # ================= delete  ================
 
   def raw_delete_volume
@@ -64,6 +74,8 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
     ext_management_system.autosde_client.VolumeApi.volumes_safe_delete(ems_ref)
     queue_refresh
   end
+
+  # ================ clone ================
 
   def raw_clone_volume(options)
     opts = ext_management_system.autosde_client.VolumeClone(

--- a/app/models/manageiq/providers/autosde/storage_manager/host_initiator.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/host_initiator.rb
@@ -37,6 +37,15 @@ class ManageIQ::Providers::Autosde::StorageManager::HostInitiator < ::HostInitia
     ext_management_system.class::EmsRefreshWorkflow.create_job(options).tap(&:signal_start)
   end
 
+  def self.create_volume_queue(userid, ext_management_system, options = {})
+    task_opts = {
+      :action => "Queuing creating Host Initiator for user #{userid}",
+      :userid => userid
+    }
+
+    super(userid, ext_management_system, options, task_opts)
+  end
+
   def raw_delete_host_initiator
     task_id = ext_management_system.autosde_client.StorageHostApi.storage_hosts_pk_delete(ems_ref).task_id
     options = {

--- a/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
@@ -75,4 +75,14 @@ class ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage < ::Physical
       ext_management_system.class::EmsRefreshWorkflow.create_job(options).tap(&:signal_start)
     end
   end
+
+  def self.create_volume_queue(userid, ext_management_system, options = {})
+    task_opts = {
+      :action => "Queuing Physical Storage for user #{userid}",
+      :userid => userid
+    }
+
+    super(userid, ext_management_system, options, task_opts)
+  end
+
 end

--- a/app/models/manageiq/providers/autosde/storage_manager/storage_service.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/storage_service.rb
@@ -32,6 +32,15 @@ class ManageIQ::Providers::Autosde::StorageManager::StorageService < ::StorageSe
     ext_management_system.class::EmsRefreshWorkflow.create_job(options).tap(&:signal_start)
   end
 
+  def self.create_volume_queue(userid, ext_management_system, options = {})
+    task_opts = {
+      :action => "Queuing creating Storage Service for user #{userid}",
+      :userid => userid
+    }
+
+    super(userid, ext_management_system, options, task_opts)
+  end
+
   def raw_delete_storage_service
     task_id = ext_management_system.autosde_client.ServiceApi.services_pk_delete(ems_ref).task_id
     options = {


### PR DESCRIPTION
currently miq task queue shows a success message for sending a request to the backend as if the backend actually succeeded in performing the request, even if the request subsequently fails:
<img width="1193" alt="60eca5a2-9295-43dc-a38e-35e757503886" src="https://user-images.githubusercontent.com/74841666/232318943-56385d20-747b-468b-8b31-646a56550a12.png">

we changed this inside task_opts so that the action label will show queuing massage correctly:
<img width="2277" alt="Screenshot 2023-04-17 at 13 44 59" src="https://user-images.githubusercontent.com/74841666/232462339-99680625-b496-483d-b7b8-78f6b291e444.png">

Related code pr: https://github.com/ManageIQ/manageiq/pull/22459