### PR TITLE
Fixed massage emsrefresh completed successfully

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/ems_refresh_workflow.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/ems_refresh_workflow.rb
@@ -70,7 +70,7 @@ class ManageIQ::Providers::Autosde::StorageManager::EmsRefreshWorkflow < ManageI
     else
       signal(:abort, "error, no valid option")
     end
-    task_ids = EmsRefresh.queue_refresh_task(targets)
+    task_ids = queue_refresh_task(targets)
     if task_ids.blank?
       process_error("Failed to queue refresh", "error")
       queue_signal(:error)
@@ -80,7 +80,19 @@ class ManageIQ::Providers::Autosde::StorageManager::EmsRefreshWorkflow < ManageI
 
       queue_signal(:poll_refresh)
     end
+
   end
+
+  def queue_refresh_task(target, id = nil)
+    task_options = {
+      :action => "EmsRefresh completed successfully ",
+      :userid => "system"
+    }
+
+    EmsRefresh.queue_refresh_task(target, id, task_options)
+  end
+
+
 
   def load_transitions
     self.state ||= 'initialize'


### PR DESCRIPTION
currently there's no dedicated success message for propagating success from autosde backend to miq_task.
we only get an EmsRefresh success msg like:

<img width="1192" alt="a93b3af1-f7cb-4a64-ad4d-3b5b87161e8c" src="https://user-images.githubusercontent.com/74841666/232780831-481d98cb-d573-419e-b2da-06c3059b4eca.png">

After the changes we made it looks like this : 
<img width="1506" alt="Screenshot 2023-04-18 at 15 43 35" src="https://user-images.githubusercontent.com/74841666/232781106-a8b37d14-1afd-4428-b6db-b55085aabe38.png">


Related PR: 

- [ ] Core: https://github.com/ManageIQ/manageiq/pull/22465