### PR TITLE
fixed bug in host group/cluster argument

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/host_initiator.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/host_initiator.rb
@@ -11,14 +11,13 @@ class ManageIQ::Providers::Autosde::StorageManager::HostInitiator < ::HostInitia
     iqns = Array(options['iqn'])
     iqn_values = iqns.join(",")
 
-    host_cluster_name = options.dig('host_initiator_group', 'label')
-    host_cluster_name = '' if host_cluster_name == '<None>'
+    options['host_initiator_group'] = '' if options['host_initiator_group'] == 'none'
 
     host_initiator_to_create = ext_management_system.autosde_client.StorageHostCreate(
       :name              => options['name'],
       :port_type         => options['port_type'],
       :storage_system    => PhysicalStorage.find(options['physical_storage_id']).ems_ref,
-      :host_cluster_name => host_cluster_name,
+      :host_cluster_name => options['host_initiator_group'],
       :iqn               => iqn_values || "",
       :wwpn              => wwpn_values || "",
       :chap_name         => options['chap_name'] || "",


### PR DESCRIPTION
old code expected to get group name from the `label` in {label: 'name', value: 'id'}, but the `js` form only sent the value ('id'), not in an object/hash, which produced the error: "String does not have #dig method".

now the ui-form sends the name as the value instead of the id, and so the name is accessible directly in `options['host_initiator_group']`.

- [ ] ui pr:
 