### PR TITLE
Drop require_nested

### DIFF
--- a/app/models/manageiq/providers/autosde/inventory.rb
+++ b/app/models/manageiq/providers/autosde/inventory.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::Autosde::Inventory < ManageIQ::Providers::Inventory
-  require_nested :Collector
-  require_nested :Parser
-  require_nested :Persister
-
   # Default manager for building collector/parser/persister classes
   # when failed to get class name from refresh target automatically
   def self.default_manager_name

--- a/app/models/manageiq/providers/autosde/inventory/collector.rb
+++ b/app/models/manageiq/providers/autosde/inventory/collector.rb
@@ -1,4 +1,2 @@
 class ManageIQ::Providers::Autosde::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
-  require_nested :StorageManager
-  require_nested :TargetCollection
 end

--- a/app/models/manageiq/providers/autosde/inventory/parser.rb
+++ b/app/models/manageiq/providers/autosde/inventory/parser.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Autosde::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
-  require_nested :StorageManager
 end

--- a/app/models/manageiq/providers/autosde/inventory/persister.rb
+++ b/app/models/manageiq/providers/autosde/inventory/persister.rb
@@ -1,4 +1,2 @@
 class ManageIQ::Providers::Autosde::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
-  require_nested :StorageManager
-  require_nested :TargetCollection
 end

--- a/app/models/manageiq/providers/autosde/storage_manager.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager.rb
@@ -1,19 +1,4 @@
 class ManageIQ::Providers::Autosde::StorageManager < ManageIQ::Providers::StorageManager
-  require_nested :AutosdeClient
-  require_nested :CloudVolume
-  require_nested :CloudVolumeSnapshot
-  require_nested :ClusterVolumeMapping
-  require_nested :HostInitiatorGroup
-  require_nested :HostInitiator
-  require_nested :HostVolumeMapping
-  require_nested :PhysicalStorage
-  require_nested :Refresher
-  require_nested :RefreshWorker
-  require_nested :StorageResource
-  require_nested :StorageService
-  require_nested :VolumeMapping
-  require_nested :EventCatcher
-
   supports :authentication_status
   supports :create
   supports :storage_services

--- a/app/models/manageiq/providers/autosde/storage_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/event_catcher.rb
@@ -1,4 +1,2 @@
 class ManageIQ::Providers::Autosde::StorageManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
-  require_nested :Runner
-  require_nested :Stream
 end

--- a/app/models/manageiq/providers/autosde/storage_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/refresh_worker.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Autosde::StorageManager::RefreshWorker < MiqEmsRefreshWorker
-  require_nested :Runner
 end


### PR DESCRIPTION
Zeitwerk completely removes the need for these methods. See also: https://github.com/ManageIQ/manageiq/pull/22854