### PR TITLE
drop use of unsupported_reason_add

### DIFF
--- a/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb
@@ -2,10 +2,10 @@ class ManageIQ::Providers::Autosde::StorageManager::CloudVolume < ::CloudVolume
   supports :create
   supports :clone
   supports :update do
-    unsupported_reason_add(:update, _("the volume is not connected to an active provider")) unless ext_management_system
+    _("the volume is not connected to an active provider") unless ext_management_system
   end
   supports :snapshot_create do
-    unsupported_reason_add(:snapshot_create, _("the volume is not connected to an active provider")) unless ext_management_system
+    _("the volume is not connected to an active provider") unless ext_management_system
   end
 
   # cloud volume delete functionality is not supported for now

--- a/app/models/manageiq/providers/autosde/storage_manager/host_initiator_group.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/host_initiator_group.rb
@@ -1,10 +1,10 @@
 class ManageIQ::Providers::Autosde::StorageManager::HostInitiatorGroup < ::HostInitiatorGroup
   supports :create
   supports :update do
-    unsupported_reason_add(:update, _("the host initiator group is not connected to an active provider")) unless ext_management_system
+    _("the host initiator group is not connected to an active provider") unless ext_management_system
   end
   supports :delete do
-    unsupported_reason_add(:update, _("the host initiator group is not connected to an active provider")) unless ext_management_system
+    _("the host initiator group is not connected to an active provider") unless ext_management_system
   end
 
   def self.raw_create_host_initiator_group(ext_management_system, options = {})

--- a/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/physical_storage.rb
@@ -1,10 +1,10 @@
 class ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage < ::PhysicalStorage
   supports :create
   supports :update do
-    unsupported_reason_add(:update, _("The Physical Storage is not connected to an active Manager")) if ext_management_system.nil?
+    _("The Physical Storage is not connected to an active Manager") if ext_management_system.nil?
   end
   supports :delete do
-    unsupported_reason_add(:delete, _("The Physical Storage is not connected to an active Manager")) if ext_management_system.nil?
+    _("The Physical Storage is not connected to an active Manager") if ext_management_system.nil?
   end
   supports :validate
 

--- a/app/models/manageiq/providers/autosde/storage_manager/volume_mapping.rb
+++ b/app/models/manageiq/providers/autosde/storage_manager/volume_mapping.rb
@@ -5,7 +5,7 @@ class ManageIQ::Providers::Autosde::StorageManager::VolumeMapping < ::VolumeMapp
   supports :create
 
   supports :delete do
-    unsupported_reason_add(:delete, _("The Volume mapping is not connected to an active Manager")) if ext_management_system.nil?
+    _("The Volume mapping is not connected to an active Manager") if ext_management_system.nil?
   end
 
   def raw_delete_volume_mapping


### PR DESCRIPTION
part of:
- https://github.com/ManageIQ/manageiq/pull/22898
 
Deprecating `unsupported_reason_add`. Returning the string instead

Note, these are all the same:

```ruby
unsupported_reason_add(:feature, unsupported_reason(:feature2)) unless supports_feature2?
unsupported_reason_add(:feature, unsupported_reason(:feature2)) unless supports?(:feature2)
unsupported_reason(:feature2) unless supports?(:feature2)
unsupported_reason(:feature2)
```
